### PR TITLE
Layout spacing fixes, INR currency, demo tracking with map, floating CTA buttons

### DIFF
--- a/Layout/MainLayout.razor
+++ b/Layout/MainLayout.razor
@@ -152,6 +152,18 @@
                             </a>
 
 
+                            <a href="/my-demos"
+                               class="user-menu-item">
+
+                                <i class="bi bi-geo-alt"></i>
+
+                                <span>
+                                    @Loc.T("menu.demos", "My Demos")
+                                </span>
+
+                            </a>
+
+
                             <a href="#"
                                @onclick="Logout"
                                class="user-menu-item">
@@ -193,6 +205,8 @@
             @Body
         </article>
     </main>
+
+    <FloatingActionButtons />
 
 </div>
 

--- a/Layout/MainLayout.razor.css
+++ b/Layout/MainLayout.razor.css
@@ -74,9 +74,8 @@
 
     padding: 0;
 
-    border-radius: 11px;
-
-    background: transparent;
+    border-radius: 50%;
+    border: none;
 
     color: #ffffff;
 
@@ -86,61 +85,45 @@
 
     box-sizing: border-box;
 
+    box-shadow: 0 4px 12px rgba(11, 31, 51, 0.28);
+
     transition:
-        background 0.2s ease,
-        border-color 0.2s ease,
-        transform 0.2s ease;
+        transform 0.2s ease,
+        box-shadow 0.2s ease;
 }
 
 
 .header-icon-btn i {
-    font-size: 19px;
+    font-size: 18px;
 
     line-height: 1;
+
+    color: #ffffff;
+}
+
+
+.header-icon-btn:hover {
+    transform: translateY(-2px) scale(1.06);
+
+    box-shadow: 0 6px 16px rgba(11, 31, 51, 0.35);
 }
 
 
 /* Profit — tied to the on-page ROI section */
 
 .profit-btn {
-    border: 1px solid rgba(45, 224, 229, 0.35);
-}
+    background: linear-gradient(135deg, #1A2C54, #3D8FB5);
 
-
-.profit-btn i {
-    color: #2de0e5;
-}
-
-
-.profit-btn:hover {
-    background: rgba(45, 224, 229, 0.08);
-
-    border-color: #2de0e5;
-
-    transform: translateY(-1px);
+    margin-left: 8px; /* extra breathing room after the search box */
 }
 
 
 /* WhatsApp — external chat, kept visually distinct from Profit */
 
 .whatsapp-btn {
-    border: 1px solid rgba(32, 223, 114, 0.35);
-}
+    background: #25D366;
 
-
-.whatsapp-btn i {
-    color: #20df72;
-
-    font-size: 20px;
-}
-
-
-.whatsapp-btn:hover {
-    background: rgba(32, 223, 114, 0.08);
-
-    border-color: #20df72;
-
-    transform: translateY(-1px);
+    margin-left: -8px; /* pulls it closer to the profit button */
 }
 
 
@@ -631,6 +614,14 @@ main {
         gap: 14px;
     }
 
+    .profit-btn {
+        margin-left: 6px;
+    }
+
+    .whatsapp-btn {
+        margin-left: -6px;
+    }
+
     .header-search,
     .header-search ::deep .search-input,
     .header-search .search-input {
@@ -647,6 +638,14 @@ main {
 
     .header-actions {
         gap: 11px;
+    }
+
+    .profit-btn {
+        margin-left: 4px;
+    }
+
+    .whatsapp-btn {
+        margin-left: -4px;
     }
 
     .header-search {
@@ -682,6 +681,14 @@ main {
 
     .header-actions {
         gap: 9px;
+    }
+
+    .profit-btn {
+        margin-left: 0;
+    }
+
+    .whatsapp-btn {
+        margin-left: -3px;
     }
 
     .language-control {

--- a/Pages/Account.razor
+++ b/Pages/Account.razor
@@ -8,6 +8,7 @@
 
 <PageTitle>Your Account - Oxyniti</PageTitle>
 
+<div class="container-fluid px-4 py-5">
 @if (!isReady)
 {
     <div class="d-flex align-items-center gap-2">
@@ -153,6 +154,7 @@ else
         </div>
     </div>
 }
+</div>
 
 @code {
     private bool isReady;

--- a/Pages/Cart.razor
+++ b/Pages/Cart.razor
@@ -4,7 +4,7 @@
 @inject IAuthenticationService AuthenticationService
 @inject LocalizationService Loc
 
-<div class="container py-5">
+<div class="container-fluid px-4 py-5">
     <h2 class="mb-4">@Loc.T("cart.title", "Your Cart")</h2>
     @if (CartItems == null)
     {

--- a/Pages/Checkout.razor
+++ b/Pages/Checkout.razor
@@ -6,6 +6,7 @@
 @inject NavigationManager Nav
 @inject LocalizationService Loc
 
+<div class="container-fluid px-4 py-5">
 <h2 class="mb-4">@Loc.T("checkout.title", "Checkout")</h2>
 
 @if (!isReady)
@@ -175,6 +176,7 @@ else
         </div>
     </div>
 }
+</div>
 
 @code {
     // State

--- a/Pages/Components/FloatingActionButtons.razor
+++ b/Pages/Components/FloatingActionButtons.razor
@@ -1,0 +1,58 @@
+@inject NavigationManager Nav
+@inject IJSRuntime JSRuntime
+@inject LocalizationService Loc
+
+<div class="floating-actions">
+
+    <button class="floating-btn floating-btn-profit"
+            @onclick="GoToProfitCalculator"
+            title="@Loc.T("roi.kicker", "Profit Calc")"
+            aria-label="@Loc.T("roi.kicker", "Profit Calc")">
+
+        <i class="bi bi-graph-up-arrow"></i>
+        <span class="floating-tooltip">@Loc.T("roi.kicker", "Profit Calc")</span>
+
+    </button>
+
+    <a class="floating-btn floating-btn-whatsapp"
+       href="@SiteContact.WhatsAppLink()"
+       target="_blank"
+       rel="noopener"
+       title="@Loc.T("nav.whatsapp", "Chat with us on WhatsApp")"
+       aria-label="@Loc.T("nav.whatsapp", "Chat with us on WhatsApp")">
+
+        <i class="bi bi-whatsapp"></i>
+        <span class="floating-tooltip">@Loc.T("nav.whatsapp", "Chat on WhatsApp")</span>
+
+    </a>
+
+</div>
+
+@code {
+    protected override void OnInitialized()
+    {
+        Loc.OnChange += StateHasChanged;
+    }
+
+    private async Task GoToProfitCalculator()
+    {
+        var relative = Nav.ToBaseRelativePath(Nav.Uri);
+        var isHome = string.IsNullOrEmpty(relative) || relative.StartsWith("?");
+
+        if (isHome)
+        {
+            try
+            {
+                await JSRuntime.InvokeVoidAsync("oxynitiScroll.toId", "profit-calculator");
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"[FloatingActionButtons] Error scrolling to profit calculator: {ex}");
+            }
+        }
+        else
+        {
+            Nav.NavigateTo("/?scrollTo=profit-calculator");
+        }
+    }
+}

--- a/Pages/Components/FloatingActionButtons.razor.css
+++ b/Pages/Components/FloatingActionButtons.razor.css
@@ -1,0 +1,101 @@
+.floating-actions {
+    position: fixed;
+    right: 1.5rem;
+    bottom: 1.5rem;
+    z-index: 1030;
+    display: flex;
+    flex-direction: column;
+    gap: 0.9rem;
+    pointer-events: none;
+}
+
+.floating-btn {
+    pointer-events: auto;
+    position: relative;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 52px;
+    height: 52px;
+    border-radius: 50%;
+    border: none;
+    cursor: pointer;
+    text-decoration: none;
+    box-shadow: 0 8px 20px rgba(11, 31, 51, 0.28);
+    opacity: 0;
+    transform: translateX(24px);
+    animation: floatIn 0.45s ease forwards;
+    transition: transform 0.25s ease, box-shadow 0.25s ease;
+}
+
+    .floating-btn:hover {
+        transform: translateY(-3px) scale(1.06);
+        box-shadow: 0 12px 26px rgba(11, 31, 51, 0.35);
+    }
+
+    .floating-btn i {
+        font-size: 1.4rem;
+        color: #fff;
+        line-height: 1;
+    }
+
+.floating-btn-profit {
+    background: linear-gradient(135deg, #1A2C54, #3D8FB5);
+    animation-delay: 0.05s;
+}
+
+.floating-btn-whatsapp {
+    background: #25D366;
+    animation-delay: 0.2s;
+}
+
+.floating-tooltip {
+    position: absolute;
+    right: calc(100% + 12px);
+    top: 50%;
+    transform: translateY(-50%) translateX(6px);
+    background: #1A2C54;
+    color: #fff;
+    font-size: 0.82rem;
+    font-weight: 600;
+    white-space: nowrap;
+    padding: 0.4rem 0.75rem;
+    border-radius: 0.4rem;
+    box-shadow: 0 4px 12px rgba(11, 31, 51, 0.25);
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.2s ease, transform 0.2s ease;
+}
+
+.floating-btn:hover .floating-tooltip {
+    opacity: 1;
+    transform: translateY(-50%) translateX(0);
+}
+
+@keyframes floatIn {
+    to {
+        opacity: 1;
+        transform: translateX(0);
+    }
+}
+
+@media (max-width: 768px) {
+    .floating-actions {
+        right: 1rem;
+        bottom: 5.5rem;
+        gap: 0.75rem;
+    }
+
+    .floating-btn {
+        width: 46px;
+        height: 46px;
+    }
+
+        .floating-btn i {
+            font-size: 1.2rem;
+        }
+
+    .floating-tooltip {
+        display: none;
+    }
+}

--- a/Pages/Components/Footer.razor.css
+++ b/Pages/Components/Footer.razor.css
@@ -1,25 +1,24 @@
 .site-footer {
     background: linear-gradient(180deg, #0B1F33 0%, #1C4E6E 100%);
-    padding: 3rem 0 1.5rem;
+    padding: 3.5rem 0 1.5rem;
     color: rgba(255, 255, 255, 0.9);
 }
 
 .container {
-    max-width: 1200px;
+    max-width: 1440px;
     margin: 0 auto;
-    padding: 0 1.5rem;
+    padding: 0 2rem;
 }
 
 .footer-content {
-    display: flex;
-    flex-wrap: wrap;
+    display: grid;
+    grid-template-columns: minmax(240px, 1.5fr) minmax(320px, 1fr);
     gap: 3rem;
-    margin-bottom: 2rem;
+    margin-bottom: 2.5rem;
 }
 
 .footer-brand {
-    flex: 1;
-    min-width: 200px;
+    min-width: 0;
 }
 
 .footer-logo {
@@ -73,23 +72,24 @@
         }
 
 .footer-links {
-    flex: 2;
-    display: flex;
-    flex-wrap: wrap;
+    display: grid;
+    grid-template-columns: repeat(2, minmax(140px, 1fr));
     gap: 2rem;
-    justify-content: space-between;
 }
 
 .footer-section {
-    min-width: 160px;
+    min-width: 0;
 }
 
     .footer-section h4 {
         font-size: 1.1rem;
         margin-top: 0;
         margin-bottom: 1rem;
+        padding-bottom: 0.5rem;
         font-weight: 600;
         color: #fff;
+        border-bottom: 2px solid rgba(141, 220, 238, 0.35);
+        display: inline-block;
     }
 
     .footer-section ul {
@@ -133,12 +133,12 @@
 
 @media (max-width: 768px) {
     .footer-content {
-        flex-direction: column;
+        grid-template-columns: 1fr;
         gap: 2rem;
     }
 
     .footer-links {
-        flex-direction: column;
+        grid-template-columns: 1fr 1fr;
         gap: 1.5rem;
     }
 

--- a/Pages/Components/FreeDemoSection.razor
+++ b/Pages/Components/FreeDemoSection.razor
@@ -1,5 +1,8 @@
 @using System.ComponentModel.DataAnnotations
+@using Oxyniti.Services
 @inject LocalizationService Loc
+@inject IJSRuntime JS
+@inject DemoService DemoService
 
 <div class="free-demo-section" id="free-demo">
     <div class="demo-grid">
@@ -52,6 +55,10 @@
                     <label>@Loc.T("f.place", "Village / Town")</label>
                     <InputText @bind-Value="model.Place" placeholder="@Loc.T("f.place.ph", "e.g. Lalgudi, Trichy")" />
                 </div>
+                <div class="field full">
+                    <label>@Loc.T("f.map", "Pond location (tap the map to mark it — optional)")</label>
+                    <div id="@mapId" class="demo-picker-map"></div>
+                </div>
                 <div class="field">
                     <label>@Loc.T("f.size", "Pond size")</label>
                     <InputSelect @bind-Value="model.Size">
@@ -88,15 +95,53 @@
 @code {
     private readonly DemoRequest model = new();
     private string? statusMessage;
+    private readonly string mapId = $"demo-picker-{Guid.NewGuid():N}";
+    private bool _mapInitialized;
 
     protected override void OnInitialized()
     {
         Loc.OnChange += StateHasChanged;
     }
 
-    private void HandleValidSubmit()
+    protected override async Task OnAfterRenderAsync(bool firstRender)
     {
-        // TODO: wire up to a real lead-capture endpoint / WhatsApp / email once contact details are configured.
+        if (firstRender && !_mapInitialized)
+        {
+            _mapInitialized = true;
+            await JS.InvokeVoidAsync("oxynitiMap.initPicker", mapId, null, null);
+        }
+    }
+
+    private async Task HandleValidSubmit()
+    {
+        double? lat = null, lng = null;
+        try
+        {
+            var picked = await JS.InvokeAsync<double[]?>("oxynitiMap.getPickerLocation", mapId);
+            if (picked is { Length: 2 })
+            {
+                lat = picked[0];
+                lng = picked[1];
+            }
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"[FreeDemoSection] Error reading picked location: {ex}");
+        }
+
+        // Demo bookings aren't persisted server-side yet — saved locally
+        // (see DemoService) so they show up on the "My Demos" page.
+        await DemoService.AddDemo(new DemoBooking
+        {
+            Name = model.Name,
+            Phone = model.Phone,
+            Place = model.Place,
+            Size = model.Size,
+            Species = model.Species,
+            Latitude = lat,
+            Longitude = lng
+        });
+
         statusMessage = "Demo request captured — we'll be in touch once contact details are configured.";
     }
 

--- a/Pages/Components/FreeDemoSection.razor.css
+++ b/Pages/Components/FreeDemoSection.razor.css
@@ -136,6 +136,13 @@
         grid-column: 1 / -1;
     }
 
+.demo-picker-map {
+    height: 220px;
+    border-radius: 0.5rem;
+    border: 1px solid rgba(11, 31, 51, 0.2);
+    overflow: hidden;
+}
+
     .field label {
         font-size: 0.82rem;
         font-weight: 700;

--- a/Pages/MyDemos.razor
+++ b/Pages/MyDemos.razor
@@ -1,0 +1,109 @@
+@page "/my-demos"
+@using Oxyniti.Services
+@inject DemoService DemoService
+@inject IJSRuntime JS
+@inject LocalizationService Loc
+
+<PageTitle>@Loc.T("demos.pagetitle", "My Demos - Oxyniti")</PageTitle>
+
+<div class="container-fluid px-4 py-5">
+    <h2 class="mb-1">@Loc.T("demos.title", "Live Pond Demos")</h2>
+
+    @if (demos is null)
+    {
+        <div class="d-flex align-items-center gap-2 mt-3">
+            <div class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></div>
+            <span>@Loc.T("demos.loading", "Loading demos…")</span>
+        </div>
+    }
+    else
+    {
+        <p class="text-muted mb-4">
+            @Loc.T("demos.count.prefix", "Demos given till now:")
+            <strong>@demos.Count</strong>
+        </p>
+
+        @if (demos.Count == 0)
+        {
+            <p>@Loc.T("demos.empty", "No demo requests yet.")</p>
+        }
+        else
+        {
+            <div id="@mapId" class="demos-map mb-4"></div>
+
+            <div class="list-group">
+                @foreach (var demo in demos.OrderByDescending(d => d.CreatedAtUtc))
+                {
+                    var hasLocation = demo.Latitude.HasValue && demo.Longitude.HasValue;
+                    <div class="list-group-item demo-row @(hasLocation ? "cursor-pointer" : "")"
+                         @onclick="() => FocusDemo(demo)">
+                        <div class="d-flex justify-content-between align-items-start flex-wrap gap-2">
+                            <div>
+                                <div class="fw-semibold">
+                                    @demo.Name
+                                    @if (hasLocation)
+                                    {
+                                        <i class="bi bi-geo-alt-fill text-primary ms-1" title="@Loc.T("demos.hasmap", "Shown on map")"></i>
+                                    }
+                                </div>
+                                <div class="text-muted small">
+                                    @demo.Place &middot; @demo.Species &middot; @demo.Size
+                                </div>
+                            </div>
+                            <div class="text-end">
+                                <a href="tel:@demo.Phone" class="text-decoration-none" @onclick:stopPropagation>
+                                    <i class="bi bi-telephone-fill me-1"></i>@demo.Phone
+                                </a>
+                                <div class="text-muted small">@demo.CreatedAtUtc.ToLocalTime().ToString("dd/MM/yyyy HH:mm")</div>
+                            </div>
+                        </div>
+                    </div>
+                }
+            </div>
+        }
+    }
+</div>
+
+@code {
+    private List<DemoBooking>? demos;
+    private readonly string mapId = $"demos-map-{Guid.NewGuid():N}";
+    private bool _mapInitialized;
+
+    protected override async Task OnInitializedAsync()
+    {
+        Loc.OnChange += StateHasChanged;
+        demos = await DemoService.GetDemos();
+    }
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (!_mapInitialized && demos is { Count: > 0 })
+        {
+            _mapInitialized = true;
+
+            var points = demos
+                .Where(d => d.Latitude.HasValue && d.Longitude.HasValue)
+                .Select(d => new
+                {
+                    lat = d.Latitude!.Value,
+                    lng = d.Longitude!.Value,
+                    name = d.Name,
+                    place = d.Place,
+                    phone = d.Phone,
+                    species = d.Species,
+                    size = d.Size
+                })
+                .ToArray();
+
+            await JS.InvokeVoidAsync("oxynitiMap.initDisplay", mapId, points);
+        }
+    }
+
+    private async Task FocusDemo(DemoBooking demo)
+    {
+        if (demo.Latitude.HasValue && demo.Longitude.HasValue)
+        {
+            await JS.InvokeVoidAsync("oxynitiMap.focusPoint", mapId, demo.Latitude.Value, demo.Longitude.Value);
+        }
+    }
+}

--- a/Pages/MyDemos.razor.css
+++ b/Pages/MyDemos.razor.css
@@ -1,0 +1,14 @@
+.demos-map {
+    height: 420px;
+    border-radius: 0.5rem;
+    border: 1px solid rgba(11, 31, 51, 0.15);
+    overflow: hidden;
+}
+
+.demo-row.cursor-pointer {
+    cursor: pointer;
+}
+
+    .demo-row.cursor-pointer:hover {
+        background-color: rgba(61, 143, 181, 0.06);
+    }

--- a/Pages/Orders.razor
+++ b/Pages/Orders.razor
@@ -3,6 +3,7 @@
 @inject NavigationManager Nav
 @inject LocalizationService Loc
 
+<div class="container-fluid px-4 py-5">
 <h2 class="mb-4">@Loc.T("orders.title", "Your Orders")</h2>
 
 @if (UserOrders is null)
@@ -213,6 +214,7 @@ else
     }
 
 }
+</div>
 
 @code {
     private List<OrderDetail>? UserOrders;
@@ -297,7 +299,7 @@ else
         return Loc.T("orders.date.unknown", "Unknown");
     }
 
-    private string FormatMoney(int cents) => (cents / 100.0m).ToString("C");
+    private string FormatMoney(int cents) => $"₹{(cents / 100.0m).ToString("N2", System.Globalization.CultureInfo.InvariantCulture)}";
 
     private void NavigateToProduct(string? slug)
     {

--- a/Pages/ProductDetails.razor
+++ b/Pages/ProductDetails.razor
@@ -10,7 +10,7 @@
 
 @if (Detail is null)
 {
-    <div class="product-details container py-5" aria-busy="true">
+    <div class="product-details container-fluid px-4 py-5" aria-busy="true">
         <div class="row g-5">
             <!-- Left: carousel/media skeleton -->
             <div class="col-12 col-lg-6">
@@ -132,7 +132,7 @@
 }
 else
 {
-    <div class="product-details container py-5">
+    <div class="product-details container-fluid px-4 py-5">
         <div class="row g-5">
             <!-- Left: Main Image Only -->
             <div class="col-12 col-lg-6">
@@ -223,7 +223,7 @@ else
                     }
 
                     <h2>@Detail.Name</h2>
-                    <p class="fs-4 fw-bold text-purple">$@Detail.Price</p>
+                    <p class="fs-4 fw-bold text-purple">₹@Detail.Price</p>
                     <div class="mb-3">
                         <label class="form-label">@Loc.T("pd.quantity.label", "Quantity")</label>
                         <div class="d-inline-flex align-items-center">

--- a/Pages/Products.razor
+++ b/Pages/Products.razor
@@ -1,7 +1,7 @@
 ﻿@page "/products"
 @inject NavigationManager Nav
 
-<div class="container py-5">
+<div class="container-fluid px-4 py-5">
     <ExploreProductRange @bind-SearchTerm="SearchTerm" />
 
     <DiscoverProductTypes />

--- a/Pages/ProductsByFilter.razor
+++ b/Pages/ProductsByFilter.razor
@@ -6,7 +6,7 @@
 @inject IJSRuntime JS
 @inject LocalizationService Loc
 
-<div class="container py-5">
+<div class="container-fluid px-4 py-5">
 
     <!-- Top Section: Title / Subtitle / Search & Filters -->
     <div class="top-section d-flex justify-content-between align-items-start mb-5">
@@ -127,7 +127,7 @@
                     @Shorten(p.Description, 150)
                 </p>
 
-                <p class="fw-bold text-purple">$@p.Price</p>
+                <p class="fw-bold text-purple">₹@p.Price</p>
             </div>
             <div class="product-action col-auto">
                 <button @onclick:stopPropagation

--- a/Program.cs
+++ b/Program.cs
@@ -16,6 +16,7 @@ builder.RootComponents.Add<HeadOutlet>("head::after");
 
 builder.Services.AddSingleton(sp => new HttpClient { BaseAddress = new Uri(builder.HostEnvironment.BaseAddress) });
 builder.Services.AddSingleton<CartService>();
+builder.Services.AddSingleton<DemoService>();
 builder.Services.AddSingleton<BusinessInfoService>();
 builder.Services.AddSingleton<LocalizationService>();
 builder.Services.AddOptions<StripeSettings>()

--- a/Services/DemoBooking.cs
+++ b/Services/DemoBooking.cs
@@ -1,0 +1,14 @@
+namespace Oxyniti.Services;
+
+public class DemoBooking
+{
+    public string Id { get; set; } = Guid.NewGuid().ToString("N");
+    public string Name { get; set; } = string.Empty;
+    public string Phone { get; set; } = string.Empty;
+    public string Place { get; set; } = string.Empty;
+    public string Size { get; set; } = string.Empty;
+    public string Species { get; set; } = string.Empty;
+    public double? Latitude { get; set; }
+    public double? Longitude { get; set; }
+    public DateTime CreatedAtUtc { get; set; } = DateTime.UtcNow;
+}

--- a/Services/DemoService.cs
+++ b/Services/DemoService.cs
@@ -1,0 +1,48 @@
+using Microsoft.JSInterop;
+using System.Text.Json;
+
+namespace Oxyniti.Services;
+
+// Demo bookings aren't persisted server-side yet (no such API exists on
+// IMakerClient) — this keeps them in localStorage as a placeholder until a
+// real backend lands. See FreeDemoSection.razor and Pages/MyDemos.razor.
+public class DemoService(IJSRuntime jsRuntime)
+{
+    private readonly IJSRuntime _jsRuntime = jsRuntime;
+    private const string StorageKey = "oxyniti_demos";
+
+    public event Action? OnChange;
+
+    private void NotifyStateChanged() => OnChange?.Invoke();
+
+    public async Task<List<DemoBooking>> GetDemos()
+    {
+        var json = await _jsRuntime.InvokeAsync<string>("localStorage.getItem", StorageKey);
+        if (string.IsNullOrEmpty(json))
+            return [];
+
+        try
+        {
+            return JsonSerializer.Deserialize<List<DemoBooking>>(json) ?? [];
+        }
+        catch (JsonException)
+        {
+            await _jsRuntime.InvokeVoidAsync("localStorage.removeItem", StorageKey);
+            return [];
+        }
+    }
+
+    public async Task AddDemo(DemoBooking demo)
+    {
+        var demos = await GetDemos();
+        demos.Add(demo);
+        await SaveDemos(demos);
+        NotifyStateChanged();
+    }
+
+    private async Task SaveDemos(List<DemoBooking> demos)
+    {
+        var json = JsonSerializer.Serialize(demos);
+        await _jsRuntime.InvokeVoidAsync("localStorage.setItem", StorageKey, json);
+    }
+}

--- a/wwwroot/index.html
+++ b/wwwroot/index.html
@@ -24,6 +24,8 @@
     <link rel="stylesheet" href="bootstrap/dist/css/bootstrap.min.css" />
     <link href="Oxyniti.styles.css" rel="stylesheet" />
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
+    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"
+          integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin="" />
 </head>
 
 <body>
@@ -42,6 +44,9 @@
     <script src="./js/clickOutsideHelper.js"></script>
     <script src="./js/tankBubbles.js"></script>
     <script src="./js/scrollHelper.js"></script>
+    <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"
+            integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=" crossorigin=""></script>
+    <script src="./js/mapHelper.js"></script>
     <script src="_framework/blazor.webassembly.js"></script>
     <script src="https://js.stripe.com/v3/"></script>
     <script>

--- a/wwwroot/js/mapHelper.js
+++ b/wwwroot/js/mapHelper.js
@@ -1,0 +1,94 @@
+function escapeHtml(str) {
+    if (str === null || str === undefined) return '';
+    return String(str)
+        .replaceAll('&', '&amp;')
+        .replaceAll('<', '&lt;')
+        .replaceAll('>', '&gt;')
+        .replaceAll('"', '&quot;')
+        .replaceAll("'", '&#39;');
+}
+
+window.oxynitiMap = {
+    _maps: {},
+
+    // Default view centered on Tamil Nadu / South India (Oxyniti's pilot territory).
+    _defaultLat: 10.9,
+    _defaultLng: 78.7,
+    _defaultZoom: 7,
+
+    _addTiles: function (map) {
+        L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+            maxZoom: 19,
+            attribution: '&copy; OpenStreetMap contributors'
+        }).addTo(map);
+    },
+
+    initPicker: function (elementId, lat, lng) {
+        this._destroy(elementId);
+
+        const hasStart = lat !== null && lat !== undefined && lng !== null && lng !== undefined;
+        const startLat = hasStart ? lat : this._defaultLat;
+        const startLng = hasStart ? lng : this._defaultLng;
+
+        const map = L.map(elementId).setView([startLat, startLng], hasStart ? 13 : this._defaultZoom);
+        this._addTiles(map);
+
+        let marker = hasStart ? L.marker([startLat, startLng], { draggable: true }).addTo(map) : null;
+
+        const placeMarker = (latlng) => {
+            if (marker) {
+                marker.setLatLng(latlng);
+            } else {
+                marker = L.marker(latlng, { draggable: true }).addTo(map);
+            }
+        };
+
+        map.on('click', (e) => placeMarker(e.latlng));
+
+        this._maps[elementId] = { map, getMarker: () => marker };
+    },
+
+    getPickerLocation: function (elementId) {
+        const entry = this._maps[elementId];
+        const marker = entry && entry.getMarker ? entry.getMarker() : null;
+        if (!marker) return null;
+        const pos = marker.getLatLng();
+        return [pos.lat, pos.lng];
+    },
+
+    initDisplay: function (elementId, points) {
+        this._destroy(elementId);
+
+        const map = L.map(elementId);
+        this._addTiles(map);
+
+        if (!points || !points.length) {
+            map.setView([this._defaultLat, this._defaultLng], this._defaultZoom);
+            this._maps[elementId] = { map };
+            return;
+        }
+
+        const markers = points.map(p => {
+            const marker = L.marker([p.lat, p.lng]).addTo(map);
+            marker.bindPopup(
+                `<b>${escapeHtml(p.name)}</b><br/>${escapeHtml(p.place)}<br/>${escapeHtml(p.phone)}<br/>` +
+                `<span style="color:#666">${escapeHtml(p.species)} &middot; ${escapeHtml(p.size)}</span>`
+            );
+            return marker;
+        });
+
+        const group = L.featureGroup(markers);
+        map.fitBounds(group.getBounds().pad(0.2));
+        if (points.length === 1) map.setZoom(13);
+
+        this._maps[elementId] = { map };
+    },
+
+    _destroy: function (elementId) {
+        const entry = this._maps[elementId];
+        if (entry) {
+            entry.map.remove();
+            delete this._maps[elementId];
+        }
+    }
+};


### PR DESCRIPTION
## Summary
- Fixed edge-to-edge (no left/right gutter) content on Orders, Account, Products, ProductsByFilter, Cart, Checkout, and ProductDetails pages, plus reworked footer spacing/layout for a tighter, more balanced look
- Switched all price displays from $/£ to ₹ (hardcoded INR for now; location-based currency switching is a planned follow-up)
- Wired the "Book a free demo" form to actually persist bookings (previously a no-op TODO), including a Leaflet map picker so the requester can pin their pond's exact location
- Added a "My Demos" page + nav menu entry showing a running count of demo bookings and a map of all booked locations with contact details
- Added floating Profit Calculator / WhatsApp buttons (fixed bottom-right) alongside the existing top-bar icons, and restyled both sets to a consistent solid-circle look

## Notes
- Demo bookings are stored in `localStorage` via a new `DemoService` as a placeholder — there's no backend API for demo tracking yet on `IMakerClient`. Swapping in real persistence later is isolated to `DemoService`.
- Leaflet + OpenStreetMap is loaded via CDN (no API key required).

## Test plan
- [ ] `dotnet build` passes (verified locally)
- [ ] Visit Orders/Account/Products/ProductsByFilter/Cart/Checkout/ProductDetails and confirm left/right gutters look correct at various widths
- [ ] Submit the "Book a free demo" form, pin a location on the map, and confirm it appears on `/my-demos` with the correct pin and contact details
- [ ] Confirm prices show ₹ everywhere (Orders, Products, Product detail)
- [ ] Confirm floating Profit Calc / WhatsApp buttons appear bottom-right on all pages, don't overlap the mobile "Book a Free Demo" bar, and top-bar icons match the new circular style

🤖 Generated with [Claude Code](https://claude.com/claude-code)