### PR TITLE
Add Free Pond Demo user entry flow (frontend-ready for backend)

### DIFF
--- a/Configuration/OxynitiApiSettings.cs
+++ b/Configuration/OxynitiApiSettings.cs
@@ -1,0 +1,12 @@
+namespace Oxyniti.Configuration;
+
+// Base address for Oxyniti's own backend (account creation, passcode issuance,
+// profile updates). Separate from RampEdgeSettings, which points at the
+// existing Maker.RampEdge product API. Leave BaseAddress empty until the
+// Oxyniti backend is deployed — DemoAccountService treats "not configured"
+// as an expected, gracefully-handled state rather than an error.
+public class OxynitiApiSettings
+{
+    public const string SectionName = "OxynitiApi";
+    public string BaseAddress { get; set; } = string.Empty;
+}

--- a/Pages/Account.razor
+++ b/Pages/Account.razor
@@ -1,154 +1,144 @@
 @page "/account"
-@using System.ComponentModel.DataAnnotations
 @using System.IdentityModel.Tokens.Jwt
-@inject IMakerClient MakerClient
+@using Oxyniti.Services
+@inject IJSRuntime JSRuntime
 @inject IAuthenticationService AuthenticationService
+@inject IDemoAccountService DemoAccountService
+@inject CartService CartService
 @inject NavigationManager Nav
 @inject LocalizationService Loc
 
 <PageTitle>Your Account - Oxyniti</PageTitle>
 
-<div class="container-fluid px-4 py-5">
+<div class="account-page">
 @if (!isReady)
 {
-    <div class="d-flex align-items-center gap-2">
+    <div class="d-flex align-items-center gap-2 p-4">
         <div class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></div>
         <span>@Loc.T("account.loading", "Loading account…")</span>
     </div>
 }
 else
 {
-    <h2 class="mb-4">@Loc.T("account.title", "Your Account")</h2>
+    <div class="account-shell">
+        <aside class="account-sidebar">
+            <nav class="sidebar-nav">
+                <span class="sidebar-item active">
+                    <i class="bi bi-person-fill"></i> @Loc.T("account.nav.profile", "Profile")
+                </span>
+                <a class="sidebar-item" href="/my-demos">
+                    <i class="bi bi-geo-alt-fill"></i> @Loc.T("account.nav.demos", "My Demos")
+                </a>
+                <a class="sidebar-item" href="/orders">
+                    <i class="bi bi-box-seam-fill"></i> @Loc.T("account.nav.orders", "My Orders")
+                </a>
+                <button type="button" class="sidebar-item sidebar-logout" @onclick="HandleLogout">
+                    <i class="bi bi-box-arrow-right"></i> @Loc.T("account.nav.logout", "Logout")
+                </button>
+            </nav>
+        </aside>
 
-    <div class="card mb-4">
-        <div class="card-body">
-            <h5 class="card-title mb-3">@Loc.T("account.profile", "Profile")</h5>
-            <p class="mb-1"><strong>@Loc.T("account.email", "Email:")</strong> @(email ?? Loc.T("account.unknown", "Unknown"))</p>
-        </div>
-    </div>
+        <div class="account-main">
+            <div class="account-header">
+                <div>
+                    <h2 class="mb-1">@Loc.T("account.title", "My Account")</h2>
+                    <p class="text-muted mb-0">@Loc.T("account.subtitle", "Manage your account details")</p>
+                </div>
+                @if (isPasscodeVerified)
+                {
+                    <div class="verified-badge">
+                        <span class="verified-icon"><i class="bi bi-shield-fill-check"></i></span>
+                        <span class="verified-copy">
+                            <strong>@Loc.T("account.verified", "Your account is verified")</strong>
+                            <small>@Loc.T("account.verified.sub", "You can update your details anytime.")</small>
+                        </span>
+                    </div>
+                }
+            </div>
 
-    <div class="mb-3 d-flex justify-content-between align-items-center">
-        <h5 class="mb-0">@Loc.T("account.addresses", "Your Addresses")</h5>
-        <button class="btn btn-primary" @onclick="() => OpenEditor(new AddressDetails())">
-            <i class="bi bi-plus-lg"></i> @Loc.T("account.addaddress", "Add Address")
-        </button>
-    </div>
-
-    @if (addresses.Count == 0)
-    {
-        <p class="text-muted">@Loc.T("account.noaddresses", "No saved addresses yet.")</p>
-    }
-    else
-    {
-        <div class="row g-3 mb-4">
-            @foreach (var addr in addresses)
-            {
-                <div class="col-12 col-md-6">
-                    <div class="card h-100">
-                        <div class="card-body">
-                            <div class="d-flex justify-content-between align-items-start">
-                                <span class="fw-semibold">
-                                    @(!string.IsNullOrWhiteSpace(addr.Site) ? addr.Site : Loc.T("account.unnamed", "Unnamed"))
-                                </span>
-                                <button type="button"
-                                        class="btn btn-sm btn-outline-secondary"
-                                        title="@Loc.T("account.edit", "Edit")"
-                                        @onclick="() => OpenEditor(Clone(addr))">
-                                    <i class="bi bi-pencil"></i> @Loc.T("account.edit", "Edit")
-                                </button>
-                            </div>
-                            <div class="mt-2 small text-muted">
-                                @if (!string.IsNullOrWhiteSpace(addr.Address))
-                                {
-                                    <div>@addr.Address</div>
-                                }
-                                <div>
-                                    @addr.State @((!string.IsNullOrWhiteSpace(addr.State) && (!string.IsNullOrWhiteSpace(addr.Pincode) || !string.IsNullOrWhiteSpace(addr.Country))) ? "," : "")
-                                    @addr.Pincode @((!string.IsNullOrWhiteSpace(addr.Pincode) && !string.IsNullOrWhiteSpace(addr.Country)) ? "," : "")
-                                    @addr.Country
-                                </div>
-                                @if (!string.IsNullOrWhiteSpace(addr.PhoneNumber))
-                                {
-                                    <div>📞 @addr.PhoneNumber</div>
-                                }
-                            </div>
-                        </div>
+            <div class="account-card">
+                <div class="card-heading">
+                    <span class="card-icon"><i class="bi bi-person-fill"></i></span>
+                    <div>
+                        <h5 class="mb-0">@Loc.T("account.profile.info", "Profile Information")</h5>
+                        <p class="text-muted small mb-0">@Loc.T("account.profile.info.sub", "Update your personal details used for demos and communication.")</p>
                     </div>
                 </div>
-            }
-        </div>
-    }
 
-    <a href="/orders" class="btn btn-outline-dark">
-        <i class="bi bi-receipt"></i> @Loc.T("account.vieworders", "View Your Orders")
-    </a>
-}
-
-<!-- Address Editor Modal -->
-@if (editing != null)
-{
-    <div class="modal fade show d-block" tabindex="-1" style="background: rgba(0,0,0,.5);" role="dialog" aria-modal="true">
-        <div class="modal-dialog modal-lg modal-dialog-centered">
-            <div class="modal-content">
-                <div class="modal-header">
-                    <h5 class="modal-title">@((editing.BarID > 0) ? Loc.T("account.editaddress", "Edit Address") : Loc.T("account.addaddress", "Add Address"))</h5>
-                    <button type="button" class="btn-close" aria-label="Close" @onclick="CloseEditor"></button>
-                </div>
-                <EditForm Model="editorVm" OnValidSubmit="SaveAsync">
-                    <DataAnnotationsValidator />
-                    <ValidationSummary />
-
-                    <div class="modal-body">
-                        <div class="row g-3">
-                            <div class="col-md-6">
-                                <label class="form-label">@Loc.T("account.field.site", "Site")</label>
-                                <InputText class="form-control" @bind-Value="editorVm.Site" />
+                <EditForm Model="profileVm" OnValidSubmit="SaveProfileAsync">
+                    <div class="profile-grid">
+                        <div class="field">
+                            <label>@Loc.T("account.field.name", "Full Name") <span class="req">*</span></label>
+                            <InputText class="acc-input" @bind-Value="profileVm.Name" />
+                        </div>
+                        <div class="field">
+                            <label>@Loc.T("account.field.whatsapp", "WhatsApp Number") <span class="req">*</span></label>
+                            <div class="input-with-icon">
+                                <input class="acc-input" value="@profileVm.Phone" disabled />
+                                <i class="bi bi-whatsapp"></i>
                             </div>
-                            <div class="col-md-6">
-                                <label class="form-label">@Loc.T("account.email", "Email")</label>
-                                <InputText class="form-control" @bind-Value="editorVm.Email" />
-                            </div>
-
-                            <div class="col-md-6">
-                                <label class="form-label">@Loc.T("account.field.phone", "Phone Number")</label>
-                                <InputText class="form-control" @bind-Value="editorVm.PhoneNumber" />
-                            </div>
-                            <div class="col-md-6">
-                                <label class="form-label">@Loc.T("account.field.state", "State/City")</label>
-                                <InputText class="form-control" @bind-Value="editorVm.State" />
-                            </div>
-
-                            <div class="col-md-4">
-                                <label class="form-label">@Loc.T("account.field.pincode", "ZIP / Pincode")</label>
-                                <InputText class="form-control" @bind-Value="editorVm.Pincode" />
-                            </div>
-                            <div class="col-md-8">
-                                <label class="form-label">@Loc.T("account.field.country", "Country")</label>
-                                <InputText class="form-control" @bind-Value="editorVm.Country" />
-                            </div>
-
-                            <div class="col-12">
-                                <label class="form-label">@Loc.T("account.field.address", "Street Address")</label>
-                                <InputTextArea class="form-control" rows="3" @bind-Value="editorVm.Address" />
-                            </div>
+                            <small class="field-hint">@Loc.T("account.field.whatsapp.hint", "This number is used to login and cannot be changed.")</small>
+                        </div>
+                        <div class="field">
+                            <label>@Loc.T("account.field.email", "Email")</label>
+                            <input class="acc-input" value="@profileVm.Email" disabled />
+                            <small class="field-hint">@Loc.T("account.field.email.hint", "Linked to your account and cannot be changed here.")</small>
+                        </div>
+                        <div class="field">
+                            <label>@Loc.T("account.field.altphone", "Alternate Phone (Optional)")</label>
+                            <InputText class="acc-input" @bind-Value="profileVm.AlternatePhone" placeholder="@Loc.T("account.field.altphone.ph", "Enter alternate number")" />
+                        </div>
+                        <div class="field">
+                            <label>@Loc.T("account.field.place", "Village / Town") <span class="req">*</span></label>
+                            <InputText class="acc-input" @bind-Value="profileVm.Place" />
+                        </div>
+                        <div class="field">
+                            <label>@Loc.T("account.field.state", "State") <span class="req">*</span></label>
+                            <InputText class="acc-input" @bind-Value="profileVm.State" />
+                        </div>
+                        <div class="field">
+                            <label>@Loc.T("account.field.pondlocation", "Pond Location") <span class="req">*</span></label>
+                            <InputText class="acc-input" @bind-Value="profileVm.PondLocation" placeholder="@Loc.T("account.field.pondlocation.ph", "e.g. Near Lalgudi Main Road")" />
+                        </div>
+                        <div class="field">
+                            <label>@Loc.T("account.field.size", "Pond Size") <span class="req">*</span></label>
+                            <InputSelect class="acc-input" @bind-Value="profileVm.Size">
+                                <option>@Loc.T("o.size1", "Under ½ acre")</option>
+                                <option>@Loc.T("o.size2", "½ – 1 acre")</option>
+                                <option>@Loc.T("o.size3", "1 – 3 acres")</option>
+                                <option>@Loc.T("o.size4", "3+ acres / multiple ponds")</option>
+                            </InputSelect>
+                        </div>
+                        <div class="field full">
+                            <label>@Loc.T("account.field.species", "What do you farm?") <span class="req">*</span></label>
+                            <InputSelect class="acc-input" @bind-Value="profileVm.Species">
+                                <option>@Loc.T("o.sp1", "Tilapia / GIFT")</option>
+                                <option>@Loc.T("o.sp2", "Murrel (Viral meen)")</option>
+                                <option>@Loc.T("o.sp3", "Pangasius")</option>
+                                <option>@Loc.T("o.sp4", "Freshwater prawn")</option>
+                                <option>@Loc.T("o.sp5", "Carp polyculture")</option>
+                                <option>@Loc.T("o.sp6", "Biofloc / RAS")</option>
+                                <option>@Loc.T("o.sp7", "Other")</option>
+                            </InputSelect>
                         </div>
                     </div>
 
-                    <div class="modal-footer">
-                        <button type="button"
-                                class="btn btn-outline-secondary"
-                                @onclick="CloseEditor"
-                                disabled="@saving">
-                            @Loc.T("account.cancel", "Cancel")
-                        </button>
-                        <button type="submit" class="btn btn-primary" disabled="@saving">
-                            @if (saving)
-                            {
-                                <span class="spinner-border spinner-border-sm me-2" role="status" aria-hidden="true"></span>
-                            }
-                            @Loc.T("account.save", "Save")
-                        </button>
-                    </div>
+                    @if (!string.IsNullOrEmpty(profileStatusMessage))
+                    {
+                        <p class="profile-status @(profileStatusIsError ? "is-error" : "is-success")">@profileStatusMessage</p>
+                    }
+
+                    <button type="submit" class="btn-save" disabled="@profileSaving">
+                        @if (profileSaving)
+                        {
+                            <span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span>
+                        }
+                        else
+                        {
+                            <i class="bi bi-save2"></i>
+                        }
+                        @Loc.T("account.save", "Save Changes")
+                    </button>
                 </EditForm>
             </div>
         </div>
@@ -158,11 +148,11 @@ else
 
 @code {
     private bool isReady;
-    private string? email;
-    private List<AddressDetails> addresses = new();
-    private AddressDetails? editing;
-    private AddressEditorVm editorVm = new();
-    private bool saving;
+    private bool isPasscodeVerified;
+    private ProfileEditorVm profileVm = new();
+    private bool profileSaving;
+    private string? profileStatusMessage;
+    private bool profileStatusIsError;
 
     protected override async Task OnInitializedAsync()
     {
@@ -174,140 +164,84 @@ else
             return;
         }
 
-        email = GetEmailFromAccessToken(AuthenticationService.AccessToken);
+        profileVm.Email = GetClaimFromAccessToken(AuthenticationService.AccessToken, "email", JwtRegisteredClaimNames.Email) ?? string.Empty;
+        profileVm.Phone = GetClaimFromAccessToken(AuthenticationService.AccessToken, "phone_number", "phone") ?? string.Empty;
 
-        await LoadAddressesAsync();
+        var loginMethod = await JSRuntime.InvokeAsync<string?>("localStorage.getItem", "oxyniti_login_method");
+        isPasscodeVerified = loginMethod == "passcode";
+
         isReady = true;
     }
 
-    private async Task LoadAddressesAsync()
+    private async Task SaveProfileAsync()
     {
+        profileSaving = true;
+        profileStatusMessage = null;
         try
         {
-            var res = await MakerClient.GetAddressAsync();
-            addresses = res?.AddressDetails?.OrderByDescending(a => a.BarID).ToList() ?? new();
-        }
-        catch (Exception ex)
-        {
-            Console.WriteLine($"[Account] Error loading addresses: {ex}");
-            addresses = new();
-        }
-    }
-
-    private void OpenEditor(AddressDetails toEdit)
-    {
-        editing = toEdit;
-        editorVm = AddressEditorVm.From(toEdit);
-
-        if (string.IsNullOrWhiteSpace(editorVm.Email) && !string.IsNullOrWhiteSpace(email))
-        {
-            editorVm.Email = email!;
-        }
-        StateHasChanged();
-    }
-
-    private void CloseEditor()
-    {
-        if (saving) return;
-        editing = null;
-        editorVm = new();
-    }
-
-    private async Task SaveAsync()
-    {
-        if (editing is null) return;
-
-        saving = true;
-        try
-        {
-            var req = new AddressRequest
+            var result = await DemoAccountService.UpdateProfileAsync(new UpdateDemoProfileRequest
             {
-                BarID = editing.BarID,
-                AddressDetails = new AddressDetails
-                {
-                    BarID = editing.BarID,
-                    Email = editorVm.Email?.Trim() ?? "",
-                    Site = editorVm.Site?.Trim() ?? "",
-                    PhoneNumber = editorVm.PhoneNumber?.Trim() ?? "",
-                    State = editorVm.State?.Trim() ?? "",
-                    Pincode = editorVm.Pincode?.Trim() ?? "",
-                    Country = editorVm.Country?.Trim() ?? "",
-                    Address = editorVm.Address?.Trim() ?? ""
-                }
-            };
-
-            await MakerClient.UpsertAddressAsync(req);
-            await LoadAddressesAsync();
-        }
-        catch (ApiException ex)
-        {
-            Console.Error.WriteLine(ex.Message);
+                Name = profileVm.Name,
+                Phone = profileVm.Phone,
+                Email = profileVm.Email,
+                AlternatePhone = profileVm.AlternatePhone,
+                Place = profileVm.Place,
+                State = profileVm.State,
+                PondLocation = profileVm.PondLocation,
+                Size = profileVm.Size,
+                Species = profileVm.Species
+            });
+            profileStatusMessage = result.Message;
+            profileStatusIsError = !result.IsSuccess;
         }
         finally
         {
-            saving = false;
-            CloseEditor();
-            StateHasChanged();
+            profileSaving = false;
         }
     }
 
-    private static AddressDetails Clone(AddressDetails a) => new()
+    private async Task HandleLogout()
     {
-        BarID = a.BarID,
-        Email = a.Email,
-        Site = a.Site,
-        PhoneNumber = a.PhoneNumber,
-        State = a.State,
-        Pincode = a.Pincode,
-        Country = a.Country,
-        Address = a.Address
-    };
+        try
+        {
+            await AuthenticationService.LogoutAsync();
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"[Account] Error during logout: {ex}");
+        }
 
-    private static string? GetEmailFromAccessToken(string? accessToken)
+        try
+        {
+            await CartService.ClearCart();
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"[Account] Error clearing cart: {ex}");
+        }
+
+        Nav.NavigateTo("/");
+    }
+
+    private static string? GetClaimFromAccessToken(string? accessToken, params string[] claimTypes)
     {
         if (string.IsNullOrWhiteSpace(accessToken)) return null;
         var handler = new JwtSecurityTokenHandler();
         if (!handler.CanReadToken(accessToken)) return null;
         var jwt = handler.ReadJwtToken(accessToken);
-        return jwt.Claims.FirstOrDefault(c =>
-            c.Type == "email" || c.Type == JwtRegisteredClaimNames.Email)?.Value;
+        return jwt.Claims.FirstOrDefault(c => claimTypes.Contains(c.Type))?.Value;
     }
 
-    private class AddressEditorVm
+    private class ProfileEditorVm
     {
-        public long BarID { get; set; }
-
-        [Required, StringLength(200)]
-        public string Site { get; set; } = string.Empty;
-
-        [Required, EmailAddress, StringLength(200)]
+        public string Name { get; set; } = string.Empty;
+        public string Phone { get; set; } = string.Empty;
         public string Email { get; set; } = string.Empty;
-
-        [StringLength(50)]
-        public string PhoneNumber { get; set; } = string.Empty;
-
-        [StringLength(100)]
+        public string AlternatePhone { get; set; } = string.Empty;
+        public string Place { get; set; } = string.Empty;
         public string State { get; set; } = string.Empty;
-
-        [StringLength(20)]
-        public string Pincode { get; set; } = string.Empty;
-
-        [StringLength(100)]
-        public string Country { get; set; } = string.Empty;
-
-        [Required, StringLength(500)]
-        public string Address { get; set; } = string.Empty;
-
-        public static AddressEditorVm From(AddressDetails d) => new()
-        {
-            BarID = d.BarID,
-            Site = d.Site ?? string.Empty,
-            Email = d.Email ?? string.Empty,
-            PhoneNumber = d.PhoneNumber ?? string.Empty,
-            State = d.State ?? string.Empty,
-            Pincode = d.Pincode ?? string.Empty,
-            Country = d.Country ?? string.Empty,
-            Address = d.Address ?? string.Empty
-        };
+        public string PondLocation { get; set; } = string.Empty;
+        public string Size { get; set; } = "½ – 1 acre";
+        public string Species { get; set; } = "Tilapia / GIFT";
     }
 }

--- a/Pages/Account.razor.css
+++ b/Pages/Account.razor.css
@@ -1,0 +1,309 @@
+.account-page {
+    background: linear-gradient(180deg, #EAF6FB 0%, #F5FBFD 45%, #F5FBFD 100%);
+    min-height: calc(100vh - 80px);
+    padding: 2.5rem 1.25rem 4rem;
+}
+
+.account-shell {
+    display: grid;
+    grid-template-columns: 240px 1fr;
+    gap: 1.75rem;
+    max-width: 1180px;
+    margin: 0 auto;
+    align-items: start;
+}
+
+/* Sidebar */
+
+.account-sidebar {
+    background: #fff;
+    border: 1px solid rgba(61, 143, 181, 0.14);
+    border-radius: 1rem;
+    padding: 1rem;
+    box-shadow: 0 4px 16px rgba(11, 31, 51, 0.06);
+}
+
+.sidebar-nav {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+}
+
+.sidebar-item {
+    display: flex;
+    align-items: center;
+    gap: 0.65rem;
+    padding: 0.7rem 0.9rem;
+    border-radius: 0.65rem;
+    color: #3a3a3a;
+    font-weight: 500;
+    font-size: 0.92rem;
+    text-decoration: none;
+    background: transparent;
+    border: none;
+    text-align: left;
+    cursor: pointer;
+    transition: background-color 0.2s, color 0.2s;
+}
+
+    .sidebar-item i {
+        color: #3D8FB5;
+        font-size: 1rem;
+        width: 1.1rem;
+        text-align: center;
+    }
+
+    .sidebar-item:hover {
+        background: #EAF6FB;
+        color: #1A2C54;
+    }
+
+    .sidebar-item.active {
+        background: #E4F1FA;
+        color: #1A2C54;
+        font-weight: 700;
+    }
+
+        .sidebar-item.active i {
+            color: #1A2C54;
+        }
+
+    .sidebar-item.sidebar-logout {
+        margin-top: 0.5rem;
+        border-top: 1px solid rgba(11, 31, 51, 0.08);
+        padding-top: 0.85rem;
+        border-radius: 0 0 0.65rem 0.65rem;
+    }
+
+        .sidebar-item.sidebar-logout i {
+            color: #b3261e;
+        }
+
+/* Header */
+
+.account-main {
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+}
+
+.account-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    flex-wrap: wrap;
+}
+
+    .account-header h2 {
+        color: #1A2C54;
+        font-weight: 700;
+    }
+
+.verified-badge {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    background: linear-gradient(160deg, #ffffff 0%, #E4F1FA 100%);
+    border: 1px solid rgba(61, 143, 181, 0.18);
+    border-radius: 0.75rem;
+    padding: 0.65rem 1.1rem;
+    box-shadow: 0 4px 14px rgba(11, 31, 51, 0.06);
+}
+
+.verified-icon {
+    width: 36px;
+    height: 36px;
+    flex-shrink: 0;
+    border-radius: 50%;
+    background: #1A2C54;
+    color: #fff;
+    display: grid;
+    place-items: center;
+    font-size: 1.05rem;
+}
+
+.verified-copy {
+    display: flex;
+    flex-direction: column;
+    line-height: 1.3;
+}
+
+    .verified-copy strong {
+        color: #1A2C54;
+        font-size: 0.9rem;
+    }
+
+    .verified-copy small {
+        color: #667;
+        font-size: 0.78rem;
+    }
+
+/* Cards */
+
+.account-card {
+    background: linear-gradient(160deg, #ffffff 0%, #F1F8FB 100%);
+    border: 1px solid rgba(61, 143, 181, 0.16);
+    border-radius: 1rem;
+    padding: 1.75rem 1.5rem;
+    box-shadow: 0 4px 20px rgba(11, 31, 51, 0.06);
+}
+
+.card-heading {
+    display: flex;
+    align-items: center;
+    gap: 0.9rem;
+    margin-bottom: 1.5rem;
+}
+
+    .card-heading h5 {
+        color: #1A2C54;
+        font-weight: 700;
+    }
+
+.card-icon {
+    width: 42px;
+    height: 42px;
+    flex-shrink: 0;
+    border-radius: 0.75rem;
+    background: rgba(61, 143, 181, 0.14);
+    color: #1A2C54;
+    display: grid;
+    place-items: center;
+    font-size: 1.15rem;
+}
+
+/* Profile form */
+
+.profile-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 1.15rem 1.5rem;
+    margin-bottom: 1.25rem;
+}
+
+.field {
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+}
+
+    .field.full {
+        grid-column: 1 / -1;
+    }
+
+    .field label {
+        font-size: 0.82rem;
+        font-weight: 700;
+        color: #1A2C54;
+    }
+
+    .field .req {
+        color: #d9534f;
+    }
+
+.field ::deep .acc-input {
+    width: 100%;
+    background: #F0F6FA;
+    border: 1px solid rgba(11, 31, 51, 0.12);
+    border-radius: 0.65rem;
+    color: #1A2C54;
+    padding: 0.75rem 1rem;
+    font-size: 0.95rem;
+    outline: none;
+    transition: border-color 0.25s, box-shadow 0.25s, background-color 0.25s;
+}
+
+    .field ::deep .acc-input:focus {
+        background: #fff;
+        border-color: #3D8FB5;
+        box-shadow: 0 0 0 3px rgba(61, 143, 181, 0.15);
+    }
+
+    .field ::deep .acc-input::placeholder {
+        color: rgba(11, 31, 51, 0.38);
+    }
+
+    .field ::deep .acc-input:disabled {
+        background: #E9EDF1;
+        color: #6b7686;
+        cursor: not-allowed;
+    }
+
+.input-with-icon {
+    position: relative;
+}
+
+    .input-with-icon ::deep .acc-input {
+        padding-right: 2.5rem;
+    }
+
+    .input-with-icon i {
+        position: absolute;
+        right: 0.9rem;
+        top: 50%;
+        transform: translateY(-50%);
+        color: #25D366;
+        font-size: 1rem;
+    }
+
+.field-hint {
+    color: #6b7686;
+    font-size: 0.78rem;
+    font-style: italic;
+}
+
+.profile-status {
+    margin: 0 0 1rem;
+    font-size: 0.88rem;
+    font-weight: 600;
+}
+
+    .profile-status.is-success {
+        color: #1a7f4e;
+    }
+
+    .profile-status.is-error {
+        color: #b3261e;
+    }
+
+.btn-save {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.6rem;
+    background-color: #1A2C54;
+    color: #fff;
+    font-weight: 600;
+    padding: 0.75rem 1.5rem;
+    border-radius: 0.6rem;
+    border: none;
+    font-size: 0.95rem;
+    cursor: pointer;
+    box-shadow: 0 4px 10px rgba(11, 31, 51, 0.2);
+    transition: background-color 0.25s, transform 0.2s;
+}
+
+    .btn-save:hover:not(:disabled) {
+        background-color: #489FB5;
+        transform: translateY(-1px);
+    }
+
+    .btn-save:disabled {
+        opacity: 0.7;
+        cursor: not-allowed;
+    }
+
+@media (max-width: 900px) {
+    .account-shell {
+        grid-template-columns: 1fr;
+    }
+
+    .account-sidebar {
+        order: 2;
+    }
+
+    .profile-grid {
+        grid-template-columns: 1fr;
+    }
+}

--- a/Pages/Components/FreeDemoSection.razor
+++ b/Pages/Components/FreeDemoSection.razor
@@ -3,6 +3,7 @@
 @inject LocalizationService Loc
 @inject IJSRuntime JS
 @inject DemoService DemoService
+@inject IDemoAccountService DemoAccountService
 
 <div class="free-demo-section" id="free-demo">
     <div class="demo-grid">
@@ -89,7 +90,7 @@
             {
                 <p class="form-status">@statusMessage</p>
             }
-            <p class="form-note">@Loc.T("f.note", "No spam, ever.")</p>
+            <p class="form-note">@Loc.T("f.note", "We respect your privacy — no spam, ever.")</p>
         </EditForm>
         </div>
     </div>
@@ -145,7 +146,23 @@
             Longitude = lng
         });
 
-        statusMessage = "Demo request captured — we'll be in touch once contact details are configured.";
+        // This is the user's entry point — no signup/login required first.
+        // Ask the (not-yet-deployed) Oxyniti backend to create their account
+        // and send a WhatsApp passcode; see DemoAccountService for the contract.
+        var accountResult = await DemoAccountService.CreateAccountAndSendPasscodeAsync(new CreateDemoAccountRequest
+        {
+            Name = model.Name,
+            Phone = model.Phone,
+            Place = model.Place,
+            Size = model.Size,
+            Species = model.Species,
+            Latitude = lat,
+            Longitude = lng
+        });
+
+        statusMessage = accountResult.IsSuccess
+            ? "Demo request received! Your login passcode has been sent to your WhatsApp."
+            : "Demo request received! We'll contact you shortly.";
     }
 
     private class DemoRequest

--- a/Pages/Login.razor
+++ b/Pages/Login.razor
@@ -10,19 +10,45 @@
         <h2>@Loc.T("login.title", "Welcome Back 👋")</h2>
         <p class="subtitle">@Loc.T("login.subtitle1", "Today is a new day. It's your day. You shape it.")<br />@Loc.T("login.subtitle2", "Sign in to start managing your projects.")</p>
 
-        <div class="form-group">
-            <label>@Loc.T("login.email", "Email")</label>
-            <input @bind="email" type="email" placeholder="@Loc.T("login.email.placeholder", "Example@email.com")" />
+        <div class="login-mode-toggle">
+            <button type="button" class="mode-btn @(usePasscode ? "" : "active")" @onclick="() => SwitchMode(false)">
+                @Loc.T("login.mode.password", "Email")
+            </button>
+            <button type="button" class="mode-btn @(usePasscode ? "active" : "")" @onclick="() => SwitchMode(true)">
+                @Loc.T("login.mode.passcode", "WhatsApp")
+            </button>
         </div>
 
-        <div class="form-group">
-            <label>@Loc.T("login.password", "Password")</label>
-            <input @bind="password" type="password" placeholder="@Loc.T("login.password.placeholder", "at least 8 characters")" />
-        </div>
+        @if (!usePasscode)
+        {
+            <div class="form-group">
+                <label>@Loc.T("login.email", "Email")</label>
+                <input @bind="email" type="email" placeholder="@Loc.T("login.email.placeholder", "Example@email.com")" />
+            </div>
 
-        <div class="forgot-password">
-            <a href="#">@Loc.T("login.forgot", "Forgot Password?")</a>
-        </div>
+            <div class="form-group">
+                <label>@Loc.T("login.password", "Password")</label>
+                <input @bind="password" type="password" placeholder="@Loc.T("login.password.placeholder", "at least 8 characters")" />
+            </div>
+
+            <div class="forgot-password">
+                <a href="#">@Loc.T("login.forgot", "Forgot Password?")</a>
+            </div>
+        }
+        else
+        {
+            <div class="form-group">
+                <label>@Loc.T("login.phone", "WhatsApp number")</label>
+                <input @bind="phone" type="tel" placeholder="@Loc.T("login.phone.placeholder", "+91 ...")" />
+            </div>
+
+            <div class="form-group">
+                <label>@Loc.T("login.passcode", "Passcode")</label>
+                <input @bind="passcode" type="text" inputmode="numeric" placeholder="@Loc.T("login.passcode.placeholder", "Passcode from WhatsApp")" />
+            </div>
+
+            <p class="passcode-hint">@Loc.T("login.passcode.hint", "Enter the passcode you received on WhatsApp.")</p>
+        }
 
         @if (!string.IsNullOrEmpty(errorMessage))
         {
@@ -62,6 +88,9 @@
 @code {
     private string email = string.Empty;
     private string password = string.Empty;
+    private string phone = string.Empty;
+    private string passcode = string.Empty;
+    private bool usePasscode;
     private string errorMessage = string.Empty;
     private string successMessage = string.Empty;
     private bool isBusy;
@@ -71,12 +100,28 @@
         Loc.OnChange += StateHasChanged;
     }
 
+    private void SwitchMode(bool passcodeMode)
+    {
+        usePasscode = passcodeMode;
+        errorMessage = string.Empty;
+        successMessage = string.Empty;
+    }
+
     private async Task OnLogin()
     {
         errorMessage = string.Empty;
         successMessage = string.Empty;
 
-        if (string.IsNullOrWhiteSpace(email) || string.IsNullOrWhiteSpace(password))
+        // Free Pond Demo accounts log in with phone + WhatsApp passcode instead
+        // of email + password. There's no separate passcode-login endpoint yet —
+        // the compiled auth client only exposes LoginAsync(identifier, secret) —
+        // so this reuses it with the phone number as the identifier and the
+        // WhatsApp passcode as the secret. That relies on the (not-yet-built)
+        // demo account-creation backend registering accounts that way.
+        var identifier = usePasscode ? phone : email;
+        var secret = usePasscode ? passcode : password;
+
+        if (string.IsNullOrWhiteSpace(identifier) || string.IsNullOrWhiteSpace(secret))
         {
             errorMessage = Loc.T("login.error.fillfields", "Please fill in all fields.");
             return;
@@ -85,9 +130,14 @@
         isBusy = true;
         try
         {
-            bool isLoggedIn = await AuthenticationService.LoginAsync(email, password);
+            bool isLoggedIn = await AuthenticationService.LoginAsync(identifier, secret);
             if (isLoggedIn)
             {
+                // Remembered so Account.razor can show "verified" only for
+                // WhatsApp-passcode logins (implying the phone number was
+                // confirmed), not for plain email/password logins.
+                await JSRuntime.InvokeVoidAsync("localStorage.setItem", "oxyniti_login_method", usePasscode ? "passcode" : "email");
+
                 await CartService.SyncLocalCartToServerIfNeeded();
                 successMessage = Loc.T("login.success", "Login successful! Redirecting...");
                 StateHasChanged();

--- a/Pages/Login.razor.css
+++ b/Pages/Login.razor.css
@@ -28,6 +28,37 @@
         font-size: 16px;
     }
 
+.login-mode-toggle {
+    display: flex;
+    gap: 6px;
+    margin-bottom: 20px;
+    background: #ffffffaa;
+    border-radius: 8px;
+    padding: 4px;
+}
+
+    .login-mode-toggle .mode-btn {
+        flex: 1;
+        padding: 8px 10px;
+        border: none;
+        border-radius: 6px;
+        background: transparent;
+        color: #1C4E6E;
+        font-size: 13px;
+        cursor: pointer;
+    }
+
+    .login-mode-toggle .mode-btn.active {
+        background: #1C4E6E;
+        color: #fff;
+    }
+
+.passcode-hint {
+    color: #555;
+    font-size: 13px;
+    margin-bottom: 20px;
+}
+
 .form-group {
     margin-bottom: 15px;
 }
@@ -40,11 +71,25 @@
 
     .form-group input {
         width: 100%;
-        padding: 12px;
-        border: 1px solid #ccc;
-        border-radius: 6px;
+        padding: 12px 14px;
+        border: 1px solid rgba(11, 31, 51, 0.12);
+        border-radius: 10px;
+        background: #F0F6FA;
+        color: #1A2C54;
         font-size: 15px;
+        outline: none;
+        transition: border-color 0.25s, box-shadow 0.25s, background-color 0.25s;
     }
+
+        .form-group input:focus {
+            background: #fff;
+            border-color: #3D8FB5;
+            box-shadow: 0 0 0 3px rgba(61, 143, 181, 0.15);
+        }
+
+        .form-group input::placeholder {
+            color: rgba(11, 31, 51, 0.4);
+        }
 
 .forgot-password {
     text-align: right;

--- a/Program.cs
+++ b/Program.cs
@@ -19,10 +19,13 @@ builder.Services.AddSingleton<CartService>();
 builder.Services.AddSingleton<DemoService>();
 builder.Services.AddSingleton<BusinessInfoService>();
 builder.Services.AddSingleton<LocalizationService>();
+builder.Services.AddSingleton<IDemoAccountService, DemoAccountService>();
 builder.Services.AddOptions<StripeSettings>()
     .BindConfiguration("Stripe");
 builder.Services.AddOptions<RampEdgeSettings>()
     .BindConfiguration(RampEdgeSettings.SectionName);
+builder.Services.AddOptions<OxynitiApiSettings>()
+    .BindConfiguration(OxynitiApiSettings.SectionName);
 
 
 builder.Services.AddMakerClient(builder.Configuration, onUnauthorized: async req =>

--- a/Services/DemoAccountModels.cs
+++ b/Services/DemoAccountModels.cs
@@ -1,0 +1,31 @@
+namespace Oxyniti.Services;
+
+public class CreateDemoAccountRequest
+{
+    public string Name { get; set; } = string.Empty;
+    public string Phone { get; set; } = string.Empty;
+    public string Place { get; set; } = string.Empty;
+    public string Size { get; set; } = string.Empty;
+    public string Species { get; set; } = string.Empty;
+    public double? Latitude { get; set; }
+    public double? Longitude { get; set; }
+}
+
+public class UpdateDemoProfileRequest
+{
+    public string? Name { get; set; }
+    public string? Phone { get; set; }
+    public string? Email { get; set; }
+    public string? AlternatePhone { get; set; }
+    public string? Place { get; set; }
+    public string? State { get; set; }
+    public string? PondLocation { get; set; }
+    public string? Size { get; set; }
+    public string? Species { get; set; }
+}
+
+public class DemoAccountResult
+{
+    public bool IsSuccess { get; set; }
+    public string Message { get; set; } = string.Empty;
+}

--- a/Services/DemoAccountService.cs
+++ b/Services/DemoAccountService.cs
@@ -1,0 +1,69 @@
+using System.Net.Http.Json;
+using Microsoft.Extensions.Options;
+using Oxyniti.Configuration;
+
+namespace Oxyniti.Services;
+
+// Free Pond Demo -> account entry point. No such API exists yet: it isn't on
+// the compiled Maker.RampEdge client, and Oxyniti's own backend
+// (OxynitiApiSettings.BaseAddress) hasn't been deployed. This service defines
+// the contracts the demo entry flow needs so the frontend is ready to wire up
+// as soon as the backend ships:
+//   POST {BaseAddress}/api/demo-accounts   -- create the account/profile from
+//     the demo form and (ideally) send the user a passcode over WhatsApp.
+//   POST {BaseAddress}/api/account/profile -- update profile info from the
+//     Account page.
+// Login itself doesn't need a new endpoint here: it reuses the existing
+// IAuthenticationService.LoginAsync(identifier, secret) — see Login.razor —
+// on the expectation that accounts created via demo entry can log in with
+// their phone number as the identifier and their WhatsApp passcode as the
+// secret. Until BaseAddress is configured, every call below fails gracefully
+// and the caller falls back to today's local-only behaviour.
+public interface IDemoAccountService
+{
+    Task<DemoAccountResult> CreateAccountAndSendPasscodeAsync(CreateDemoAccountRequest request);
+    Task<DemoAccountResult> UpdateProfileAsync(UpdateDemoProfileRequest request);
+}
+
+public class DemoAccountService(HttpClient http, IOptions<OxynitiApiSettings> apiSettings) : IDemoAccountService
+{
+    private const string CreateAccountRoute = "api/demo-accounts";
+    private const string UpdateProfileRoute = "api/account/profile";
+
+    public Task<DemoAccountResult> CreateAccountAndSendPasscodeAsync(CreateDemoAccountRequest request) =>
+        PostAsync(CreateAccountRoute, request,
+            "We couldn't reach the account service yet — your demo request is saved and we'll be in touch.");
+
+    public Task<DemoAccountResult> UpdateProfileAsync(UpdateDemoProfileRequest request) =>
+        PostAsync(UpdateProfileRoute, request,
+            "We can't save profile changes just yet — please check back soon.");
+
+    private async Task<DemoAccountResult> PostAsync<TRequest>(string route, TRequest request, string unavailableMessage)
+    {
+        var baseAddress = apiSettings.Value.BaseAddress;
+        if (string.IsNullOrWhiteSpace(baseAddress))
+        {
+            Console.WriteLine($"[DemoAccountService] OxynitiApi:BaseAddress not configured — skipping call to {route}.");
+            return new DemoAccountResult { IsSuccess = false, Message = unavailableMessage };
+        }
+
+        try
+        {
+            var uri = new Uri(new Uri(baseAddress), route);
+            var response = await http.PostAsJsonAsync(uri, request);
+            if (response.IsSuccessStatusCode)
+            {
+                var result = await response.Content.ReadFromJsonAsync<DemoAccountResult>();
+                return result ?? new DemoAccountResult { IsSuccess = true, Message = "Done." };
+            }
+
+            Console.WriteLine($"[DemoAccountService] {route} returned {(int)response.StatusCode}.");
+            return new DemoAccountResult { IsSuccess = false, Message = unavailableMessage };
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"[DemoAccountService] Error calling {route}: {ex}");
+            return new DemoAccountResult { IsSuccess = false, Message = unavailableMessage };
+        }
+    }
+}

--- a/wwwroot/appsettings.json
+++ b/wwwroot/appsettings.json
@@ -10,6 +10,10 @@
     "BaseAddress": "https://maker-rest-api-e5c2djh7aafkace8.uksouth-01.azurewebsites.net"
   },
 
+  "OxynitiApi": {
+    "BaseAddress": ""
+  },
+
   "Stripe": {
     "PublicKey": "pk_test_51Rof3tDnJQ8f5UM3qGq1Nni0iiJE9g0J1D3OYqEpAZrtXZ4Uxy3Kzrq38Mjzd6N3o4Q7DudsgM7aStJow0PO2lzg003OUWBBJq",
     "ReturnUrl": "checkout/return?session_id={CHECKOUT_SESSION_ID}"


### PR DESCRIPTION
## Summary
- Free Pond Demo form is the user's entry point — no signup/login required before requesting a demo.
- On submit, the frontend now also calls a stubbed `IDemoAccountService.CreateAccountAndSendPasscodeAsync` — ready to create an account + send a WhatsApp passcode once the backend exists.
- Login page gains a WhatsApp/passcode mode alongside email/password, reusing the existing `IAuthenticationService.LoginAsync(identifier, secret)` call.
- Account page redesigned (sidebar nav, verified badge, editable pond/contact profile section); no separate "Join Demo" button.
- No backend endpoints exist yet. `DemoAccountService` + `OxynitiApiSettings` define the contract and fail gracefully (with user-friendly fallback messaging) until `OxynitiApi:BaseAddress` is configured.

## Backend work needed to complete the workflow
This PR is frontend-only. For the full flow to work end-to-end, backend needs to implement:

1. **Architecture decision first**: login goes through the existing `Maker.RampEdge` package (`LoginAsync(identifier, secret)`), which hits the RampEdge REST API. Whoever builds account creation must end up with a matching phone/passcode credential inside RampEdge's user store — either by extending RampEdge itself, or having a new Oxyniti service provision a matching credential there server-to-server.
2. **`POST /api/demo-accounts`** — create account from `{ name, phone, place, size, species, latitude?, longitude? }`, generate a server-side passcode (hashed, expiring, rate-limited), send it via WhatsApp, return `{ isSuccess, message }`. Should upsert on repeat phone submissions, not duplicate.
3. **`POST /api/account/profile`** — authenticated (Bearer token from `LoginAsync`), updates `{ name, phone, email, alternatePhone, place, state, pondLocation, size, species }`.
4. **`GET /api/account/profile`** — not yet stubbed on the frontend; needed so the Account page can load previously saved data instead of showing blank fields on every visit. Frontend fetch call still needs to be added once this exists.
5. **CORS** — this is a Blazor WASM app calling from the browser; the backend must send CORS headers for the app's origin.
6. **Passcode resend / expiry UX** — no resend flow exists yet on either side; needs a decision on whether passcodes are single-use.
7. **CRM integration** — undefined; needs a product decision on which CRM and push vs. pull before there's anything to build.

## Test plan
- [x] `dotnet build` succeeds with 0 warnings/errors
- [ ] Manual verification in a browser once a backend is available to log in against (not possible this session — no test credentials, no headless browser tooling in this environment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)