### PR TITLE
Update English explainer video with latest cinematic cut

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -11,3 +11,4 @@
 # git and NOT by GitHub, which ignores .gitattributes merge drivers -- that is why
 # PRs 5 and 6 conflicted on a shared events.jsonl while the local merge was clean.
 # Safety comes from the shards being disjoint, not from this line.
+wwwroot/videos/oxy-nano-series.mp4 filter=lfs diff=lfs merge=lfs -text


### PR DESCRIPTION
## Summary
- Replaces `wwwroot/videos/oxy-nano-series.mp4` (the English OXY-Nano explainer, served by `OxyNanoVideoSection.razor`) with the current cinematic cut, `oxyniti_explainer_cinematic_16x9.mp4`.
- File is 114 MB, over GitHub's 100 MB blob limit, so it's now tracked via Git LFS (scoped to just this file in `.gitattributes`).

## Test plan
- [ ] Pull the branch and confirm the video plays correctly on the site in English (non-Tamil) locale
- [ ] Confirm Tamil locale still plays its own unaffected video

🤖 Generated with [Claude Code](https://claude.com/claude-code)