### PR TITLE
Fix broken production video (Git LFS not supported by host)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -11,4 +11,3 @@
 # git and NOT by GitHub, which ignores .gitattributes merge drivers -- that is why
 # PRs 5 and 6 conflicted on a shared events.jsonl while the local merge was clean.
 # Safety comes from the shards being disjoint, not from this line.
-wwwroot/videos/oxy-nano-series.mp4 filter=lfs diff=lfs merge=lfs -text


### PR DESCRIPTION
## Summary
- Production regression: PR #17 moved `wwwroot/videos/oxy-nano-series.mp4` to Git LFS to get under GitHub's 100MB limit, but the deployment/hosting pipeline does not resolve LFS pointers. Live oxyniti.com has been serving a 134-byte pointer file as the video since that merge, so playback is completely broken for every visitor.
- Fix: untrack the file from LFS and ship a re-encoded version of the same explainer video (same 1920x1080 resolution, same 7:14 duration) at a lower bitrate (~1.67 Mbps vs ~2.2 Mbps) so it fits under 100MB as a normal git blob — no LFS resolution needed at deploy time.

## Verification
- `curl` against the live URL confirmed the current file is 134 bytes (the LFS pointer text), not video content.
- New file verified locally: 86.3 MB, same duration/resolution as the source, plays correctly.

## Test plan
- [ ] Merge and deploy, then confirm `https://oxyniti.com/videos/oxy-nano-series.mp4` returns full video content (not a small text pointer)
- [ ] Confirm video plays in English locale on the live site
- [ ] Confirm scroll-based pause/resume behavior (existing `oxyNanoVideo.js` logic, untouched by this fix) still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)