### PR TITLE
perf(P2): lazy-load Stripe.js only on checkout pages

### DIFF
--- a/Pages/Payment.razor
+++ b/Pages/Payment.razor
@@ -1,6 +1,8 @@
 ﻿@page "/payment"
 @using System.IdentityModel.Tokens.Jwt
 @using System.Net.Http.Json
+@using Microsoft.JSInterop
+@implements IAsyncDisposable
 @inject IJSRuntime JS
 @inject IOptions<StripeSettings> StripeOptions
 @inject IOptions<RampEdgeSettings> MakerSettings
@@ -18,6 +20,7 @@
     public string? Address { get; set; }
 
     private bool _mounted;
+    private IJSObjectReference? _stripeModule;
 
     protected override void OnInitialized()
     {
@@ -39,7 +42,8 @@
             var payload = await BuildCreateSessionRequest();
             var response = await MakerClient.CreateCheckoutSessionAsync(payload);
 
-            await JS.InvokeVoidAsync("mountEmbeddedCheckout",
+            _stripeModule = await JS.InvokeAsync<IJSObjectReference>("import", "./js/stripeHelper.js");
+            await _stripeModule.InvokeVoidAsync("mountEmbeddedCheckout",
                 StripeOptions.Value.PublicKey,
                 response.ClientSecret);
 
@@ -49,6 +53,21 @@
         {
             // If mount fails, just redirect or show an error UI
             Nav.NavigateTo("/checkout");
+        }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_stripeModule is null) return;
+
+        try
+        {
+            await _stripeModule.InvokeVoidAsync("dispose");
+            await _stripeModule.DisposeAsync();
+        }
+        catch (JSDisconnectedException)
+        {
+            // Safe to ignore when Blazor circuit disconnects.
         }
     }
 

--- a/wwwroot/index.html
+++ b/wwwroot/index.html
@@ -52,31 +52,6 @@
             integrity="sha256-eeyG+ChWAFsciHkFz8z8++w4Icphx/1alS+qX3ePeRw=" crossorigin=""></script>
     <script src="./js/qrHelper.js"></script>
     <script src="_framework/blazor.webassembly.js"></script>
-    <script src="https://js.stripe.com/v3/"></script>
-    <script>
-        let __embeddedCheckout = null;
-        let __stripe = null;
-
-        async function mountEmbeddedCheckout(stripePublicKey, clientSecret, containerSelector = '#checkout-container') {
-            // If already mounted, destroy first (idempotent)
-            if (__embeddedCheckout) {
-                try { await __embeddedCheckout.destroy(); } catch (_) { }
-                __embeddedCheckout = null;
-            }
-
-            if (!__stripe) {
-                __stripe = Stripe(stripePublicKey);
-            }
-
-            const el = document.querySelector(containerSelector);
-            if (!el) throw new Error(`Container ${containerSelector} not found`);
-            el.innerHTML = '';
-
-            __embeddedCheckout = await __stripe.initEmbeddedCheckout({ clientSecret });
-            await __embeddedCheckout.mount(containerSelector);
-            return true;
-        }
-    </script>
 
 </body>
 </html>

--- a/wwwroot/js/stripeHelper.js
+++ b/wwwroot/js/stripeHelper.js
@@ -1,0 +1,48 @@
+let stripePromise = null;
+let stripe = null;
+let embeddedCheckout = null;
+
+/*
+ * Stripe.js is ~1 MB and is only needed on the pages that actually take a
+ * payment, so it is fetched here on first use instead of site-wide from
+ * index.html.
+ */
+function loadStripe() {
+    stripePromise ??= new Promise((resolve, reject) => {
+        const script = document.createElement("script");
+        script.src = "https://js.stripe.com/v3/";
+        script.onload = resolve;
+        script.onerror = () => reject(new Error("Failed to load js.stripe.com"));
+        document.head.appendChild(script);
+    });
+
+    return stripePromise;
+}
+
+export async function mountEmbeddedCheckout(stripePublicKey, clientSecret, containerSelector = "#checkout-container") {
+    await loadStripe();
+
+    if (embeddedCheckout) {
+        try { await embeddedCheckout.destroy(); } catch (_) { }
+        embeddedCheckout = null;
+    }
+
+    if (!stripe) {
+        stripe = Stripe(stripePublicKey);
+    }
+
+    const el = document.querySelector(containerSelector);
+    if (!el) throw new Error(`Container ${containerSelector} not found`);
+    el.innerHTML = "";
+
+    embeddedCheckout = await stripe.initEmbeddedCheckout({ clientSecret });
+    await embeddedCheckout.mount(containerSelector);
+    return true;
+}
+
+export function dispose() {
+    if (embeddedCheckout) {
+        try { embeddedCheckout.destroy(); } catch (_) { }
+        embeddedCheckout = null;
+    }
+}


### PR DESCRIPTION
## Summary
- Removes the global `<script src="https://js.stripe.com/v3/">` and inline `mountEmbeddedCheckout` helper from `wwwroot/index.html`, which loaded ~1.05 MB of decoded JS + a hidden iframe on every page, including the homepage.
- Moves `mountEmbeddedCheckout` into a new ES module, `wwwroot/js/stripeHelper.js`, which injects the Stripe script lazily on first call (memoized via a shared promise) and exposes a `dispose()` to tear down the embedded checkout instance.
- `Pages/Payment.razor` now imports the module on demand with `JS.InvokeAsync<IJSObjectReference>("import", "./js/stripeHelper.js")` instead of calling a global function, and implements `IAsyncDisposable` to dispose the module reference when the component is torn down.

## Test plan
- [x] `dotnet build Oxyniti.sln -c Release` succeeds with 0 warnings/errors.
- [x] Verified no remaining references to `js.stripe.com` or the global `mountEmbeddedCheckout` outside the new module.
- [ ] Manual smoke test: homepage no longer requests `js.stripe.com`; `/checkout` → `/payment` still mounts the embedded checkout and completes a test payment (needs a live/staging environment with Stripe test keys — not runnable in this sandbox).

Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)