### PR TITLE
perf: add cache headers, MIME types, and Vary header

### DIFF
--- a/wwwroot/staticwebapp.config.json
+++ b/wwwroot/staticwebapp.config.json
@@ -9,5 +9,24 @@
       "/app.css",
       "/icon-192.png"
     ]
-  }
+  },
+  "mimeTypes": {
+    ".mp4": "video/mp4",
+    ".webm": "video/webm",
+    ".avif": "image/avif",
+    ".webp": "image/webp",
+    ".wasm": "application/wasm",
+    ".json": "application/json"
+  },
+  "globalHeaders": {
+    "Vary": "Accept-Encoding"
+  },
+  "routes": [
+    { "route": "/_framework/blazor.boot.json", "headers": { "Cache-Control": "public, max-age=0, must-revalidate" } },
+    { "route": "/_framework/*", "headers": { "Cache-Control": "public, max-age=31536000, immutable" } },
+    { "route": "/images/*", "headers": { "Cache-Control": "public, max-age=2592000" } },
+    { "route": "/videos/*", "headers": { "Cache-Control": "public, max-age=2592000" } },
+    { "route": "/bootstrap/*", "headers": { "Cache-Control": "public, max-age=2592000" } },
+    { "route": "/index.html", "headers": { "Cache-Control": "public, max-age=0, must-revalidate" } }
+  ]
 }


### PR DESCRIPTION
## Summary
- Add `mimeTypes` for mp4/webm/avif/webp/wasm/json so video and modern image formats stop serving as `application/octet-stream`
- Add `routes` so fingerprinted `_framework/*` assets get a 1-year immutable cache while `blazor.boot.json` and `index.html` stay short-lived (the pointers that let everything else be cached forever)
- Cache `images/*`, `videos/*`, `bootstrap/*` for 30 days
- Add `globalHeaders` `Vary: Accept-Encoding` so shared/edge caches store brotli and gzip variants separately

Fixes #29. Lays the groundwork for #36 (edge caching is only useful once assets are actually cacheable).

## Test plan
- [x] `wwwroot/staticwebapp.config.json` validated as well-formed JSON
- [ ] After this PR's Azure Static Web Apps preview deploys, `curl -I` a `/_framework/` asset and confirm `max-age=31536000, immutable`
- [ ] `curl -I` `index.html` and confirm `max-age=0, must-revalidate`
- [ ] `curl -I` an `.mp4` under `/videos/` and confirm `Content-Type: video/mp4`