### PR TITLE
infra: Azure Front Door Bicep template for #36 (review only, not deployed)

### DIFF
--- a/infra/README.md
+++ b/infra/README.md
@@ -1,0 +1,96 @@
+# Front Door in front of the site (issue #36)
+
+`infra/frontdoor.bicep` puts Azure Front Door Standard in front of the
+existing Static Web App: real edge PoPs (including India), HTTP/3 to
+clients that support it, and actual edge caching (the site currently has
+none of that — every request goes straight to wherever SWA's Traffic
+Manager routes it, measured as Hong Kong for Indian visitors, with no
+cache tier and no `x-azure-ref`/`age` headers).
+
+**This template has not been deployed.** No pipeline in this repo applies
+it. Review it, then deploy it yourself with your own Azure credentials.
+
+## What it deploys
+
+- An Azure Front Door Standard profile + endpoint
+- An origin group pointing at the Static Web App's existing default
+  hostname (`*.azurestaticapps.net`) — nothing changes on the SWA itself
+- A route with HTTPS-only forwarding, compression, and
+  `queryStringCachingBehavior: UseQueryString` (so `/oxyniti.png?v=2`
+  keeps busting cache correctly)
+- Custom domain resources for `oxyniti.com` and `www.oxyniti.com`
+
+Front Door honors the `Cache-Control` headers `staticwebapp.config.json`
+already sets (from #29) — that's why #29 had to land first.
+
+## Deploy
+
+```bash
+az login
+
+az deployment group create \
+  --resource-group <your-resource-group> \
+  --template-file infra/frontdoor.bicep \
+  --parameters staticWebAppDefaultHostname=delightful-flower-0fedcf103.3.azurestaticapps.net
+```
+
+(That hostname is `www.oxyniti.com`'s current CNAME target, confirmed via
+`dig`/`nslookup` on 2026-08-26. Re-confirm with
+`az staticwebapp show --name <name> --query defaultHostname -o tsv` in
+case it's rotated since.)
+
+I could not run `bicep build` or `az deployment group validate` against
+this template — there's no Azure CLI in the environment I authored it in.
+Run one of those (or `--what-if`) before applying for real.
+
+Grab the outputs:
+
+```bash
+az deployment group show -g <rg> -n frontdoor \
+  --query 'properties.outputs.{fd:frontDoorEndpointHostname.value, apexToken:apexDomainValidationToken.value, wwwToken:wwwDomainValidationToken.value}'
+```
+
+## DNS changes (at your registrar / DNS host)
+
+This is the part that actually fixes #36 and requires registrar access I
+don't have.
+
+1. **Domain validation** — add TXT records so Front Door can prove you own
+   the domains (skip this step if you migrate the zone to Azure DNS and
+   link it instead, which lets Front Door auto-validate):
+   - `_dnsauth.oxyniti.com` → `<apexDomainValidationToken output>`
+   - `_dnsauth.www.oxyniti.com` → `<wwwDomainValidationToken output>`
+2. **`www.oxyniti.com`** — change the existing CNAME from
+   `delightful-flower-0fedcf103.3.azurestaticapps.net` to the
+   `frontDoorEndpointHostname` output (a `*.z01.azurefd.net`-style name).
+3. **`oxyniti.com` (apex)** — a bare apex can't be a CNAME. Use whatever
+   ALIAS/ANAME/flattened-CNAME feature your DNS host offers, pointed at the
+   same `frontDoorEndpointHostname`. **This also replaces the existing
+   apex config** — right now `oxyniti.com` resolves to `15.197.225.128` /
+   `3.33.251.168` (registrar domain-forwarding, GoDaddy's IP range) and
+   301-redirects to **`http://oxyniti.com`**, downgrading to plain HTTP.
+   That's a separate bug from #36 worth fixing in the same pass: turn off
+   the registrar's HTTP-forwarding feature for the apex entirely once the
+   ALIAS record is live.
+4. Wait for `domainValidationState` to reach `Approved` on both custom
+   domains (`az afd custom-domain list ...` or the portal), then confirm
+   live:
+   ```bash
+   curl -I https://www.oxyniti.com   # look for x-azure-ref and an age header on a repeat request
+   curl -I https://oxyniti.com       # should now be a clean https 200/redirect, not an http downgrade
+   ```
+
+## Not included here
+
+- **WAF** — needs the Premium SKU (`skuName: 'Premium_AzureFrontDoor'` in
+  the template), left out to keep this on the cheaper Standard tier.
+  Switch the parameter if you want it.
+- **A second API region for `GetBusinessInfo`** (issue #36 item 5) — that
+  backend (`maker-rest-api-*.azurewebsites.net`) isn't part of this repo;
+  duplicating its region is a call for whoever owns that service.
+- **A dedicated video host** — not needed as a separate step; once Front
+  Door fronts the whole Static Web App, `/videos/*` is served through the
+  edge along with everything else.
+- Actually running the deployment and the DNS cutover — needs your Azure
+  subscription and registrar access, and it's a production DNS change I
+  shouldn't make unilaterally even if I had the credentials.

--- a/infra/README.md
+++ b/infra/README.md
@@ -19,9 +19,30 @@ it. Review it, then deploy it yourself with your own Azure credentials.
   `queryStringCachingBehavior: UseQueryString` (so `/oxyniti.png?v=2`
   keeps busting cache correctly)
 - Custom domain resources for `oxyniti.com` and `www.oxyniti.com`
+- A **second** origin group + route + custom domain (`api.oxyniti.com`)
+  fronting the existing `maker-rest-api-*.azurewebsites.net` backend — see
+  "The API leg" below before wiring the app up to it
 
 Front Door honors the `Cache-Control` headers `staticwebapp.config.json`
 already sets (from #29) — that's why #29 had to land first.
+
+### The API leg — what it does and doesn't do
+
+Issue #36 item 5 offers two options: a second API region, or a Front Door
+origin group. This template does the latter, because `maker-rest-api` isn't
+part of this repo — this repo can't move it to a second region. Routing it
+through Front Door instead means the browser's TLS/TCP handshake lands at
+a nearby PoP and the UK South hop rides Microsoft's backbone network rather
+than the public internet. That's a real latency win, but it does **not**
+eliminate the UK round trip the way a second region would — `GetBusinessInfo`
+still ultimately executes in UK South.
+
+**Do not** point `wwwroot/appsettings.json`'s `RampEdge.BaseAddress` at
+`https://api.oxyniti.com` until that domain's DNS is live and validated
+(step-by-step below) — flipping it earlier would break every `GetBusinessInfo`
+call in production, since the domain wouldn't resolve yet. Once validated,
+that's a one-line config change in a follow-up PR, not something to bundle
+into this infra change.
 
 ## Deploy
 
@@ -47,7 +68,7 @@ Grab the outputs:
 
 ```bash
 az deployment group show -g <rg> -n frontdoor \
-  --query 'properties.outputs.{fd:frontDoorEndpointHostname.value, apexToken:apexDomainValidationToken.value, wwwToken:wwwDomainValidationToken.value}'
+  --query 'properties.outputs.{fd:frontDoorEndpointHostname.value, apexToken:apexDomainValidationToken.value, wwwToken:wwwDomainValidationToken.value, apiToken:apiDomainValidationToken.value}'
 ```
 
 ## DNS changes (at your registrar / DNS host)
@@ -60,10 +81,15 @@ don't have.
    link it instead, which lets Front Door auto-validate):
    - `_dnsauth.oxyniti.com` → `<apexDomainValidationToken output>`
    - `_dnsauth.www.oxyniti.com` → `<wwwDomainValidationToken output>`
+   - `_dnsauth.api.oxyniti.com` → `<apiDomainValidationToken output>`
 2. **`www.oxyniti.com`** — change the existing CNAME from
    `delightful-flower-0fedcf103.3.azurestaticapps.net` to the
    `frontDoorEndpointHostname` output (a `*.z01.azurefd.net`-style name).
-3. **`oxyniti.com` (apex)** — a bare apex can't be a CNAME. Use whatever
+3. **`api.oxyniti.com`** — new CNAME, also pointed at
+   `frontDoorEndpointHostname`. Once this validates, that's the point to
+   open the follow-up PR flipping `RampEdge.BaseAddress` (see "The API leg"
+   above) — not before.
+4. **`oxyniti.com` (apex)** — a bare apex can't be a CNAME. Use whatever
    ALIAS/ANAME/flattened-CNAME feature your DNS host offers, pointed at the
    same `frontDoorEndpointHostname`. **This also replaces the existing
    apex config** — right now `oxyniti.com` resolves to `15.197.225.128` /
@@ -72,12 +98,13 @@ don't have.
    That's a separate bug from #36 worth fixing in the same pass: turn off
    the registrar's HTTP-forwarding feature for the apex entirely once the
    ALIAS record is live.
-4. Wait for `domainValidationState` to reach `Approved` on both custom
+5. Wait for `domainValidationState` to reach `Approved` on all three custom
    domains (`az afd custom-domain list ...` or the portal), then confirm
    live:
    ```bash
    curl -I https://www.oxyniti.com   # look for x-azure-ref and an age header on a repeat request
    curl -I https://oxyniti.com       # should now be a clean https 200/redirect, not an http downgrade
+   curl -I https://api.oxyniti.com   # should reach maker-rest-api through Front Door
    ```
 
 ## Not included here
@@ -85,9 +112,12 @@ don't have.
 - **WAF** — needs the Premium SKU (`skuName: 'Premium_AzureFrontDoor'` in
   the template), left out to keep this on the cheaper Standard tier.
   Switch the parameter if you want it.
-- **A second API region for `GetBusinessInfo`** (issue #36 item 5) — that
-  backend (`maker-rest-api-*.azurewebsites.net`) isn't part of this repo;
-  duplicating its region is a call for whoever owns that service.
+- **An actual second API region for `GetBusinessInfo`** (issue #36 item 5's
+  other option) — that backend (`maker-rest-api-*.azurewebsites.net`) isn't
+  part of this repo; duplicating its region is a call for whoever owns that
+  service. This template does the origin-group-acceleration option instead
+  (see "The API leg" above), which is weaker but doesn't require touching
+  another team's service.
 - **A dedicated video host** — not needed as a separate step; once Front
   Door fronts the whole Static Web App, `/videos/*` is served through the
   edge along with everything else.

--- a/infra/frontdoor.bicep
+++ b/infra/frontdoor.bicep
@@ -9,11 +9,19 @@
 // This template is NOT applied by any pipeline in this repo. Deploy it
 // yourself with the Azure CLI once you've reviewed it — see infra/README.md.
 //
+// Also fronts the maker-rest-api backend behind the same profile (issue #36
+// item 5's "or Azure Front Door origin group" option): the API itself still
+// only exists in UK South -- this repo doesn't own that service, so it can't
+// move it -- but routing it through Front Door means the visitor's TLS/TCP
+// handshake lands at a nearby PoP and rides Microsoft's backbone network for
+// the UK South hop instead of the public internet. It's an acceleration, not
+// a second region.
+//
 // Not covered here (see infra/README.md "Not included"):
 //   - the apex-domain (oxyniti.com, no "www") insecure HTTP forward, which
 //     is a registrar-level domain-forwarding setting, not an Azure resource
-//   - a second region for the maker-rest-api backend (owned by a different
-//     repo/service)
+//   - an actual second region for the maker-rest-api backend (owned by a
+//     different repo/service)
 //   - WAF (requires the Premium SKU, not provisioned here to keep cost down)
 
 @description('Default hostname of the Static Web App, e.g. delightful-flower-0fedcf103.3.azurestaticapps.net. Found via `az staticwebapp show`.')
@@ -24,6 +32,12 @@ param apexDomain string = 'oxyniti.com'
 
 @description('www subdomain, e.g. www.oxyniti.com')
 param wwwDomain string = 'www.oxyniti.com'
+
+@description('Hostname of the existing maker-rest-api backend (GetBusinessInfo etc.), e.g. maker-rest-api-e5c2djh7aafkace8.uksouth-01.azurewebsites.net.')
+param apiOriginHostname string = 'maker-rest-api-e5c2djh7aafkace8.uksouth-01.azurewebsites.net'
+
+@description('Subdomain to expose the API through Front Door on, e.g. api.oxyniti.com. Point wwwroot/appsettings.json RampEdge.BaseAddress at this only after its DNS is live -- see infra/README.md.')
+param apiSubdomain string = 'api.oxyniti.com'
 
 @description('Front Door profile name.')
 param profileName string = 'oxyniti-fd'
@@ -39,6 +53,9 @@ var endpointName = '${profileName}-ep'
 var originGroupName = 'swa-origin-group'
 var originName = 'swa-origin'
 var routeName = 'default-route'
+var apiOriginGroupName = 'api-origin-group'
+var apiOriginName = 'api-origin'
+var apiRouteName = 'api-route'
 
 resource profile 'Microsoft.Cdn/profiles@2024-02-01' = {
   name: profileName
@@ -166,6 +183,86 @@ resource route 'Microsoft.Cdn/profiles/afdEndpoints/routes@2024-02-01' = {
   }
 }
 
+resource apiOriginGroup 'Microsoft.Cdn/profiles/originGroups@2024-02-01' = {
+  parent: profile
+  name: apiOriginGroupName
+  properties: {
+    loadBalancingSettings: {
+      sampleSize: 4
+      successfulSamplesRequired: 3
+    }
+    healthProbeSettings: {
+      // Adjust probePath if the API doesn't respond 2xx/3xx/4xx on "/" --
+      // any non-5xx response counts as healthy for Front Door's purposes.
+      probePath: '/'
+      probeRequestType: 'HEAD'
+      probeProtocol: 'Https'
+      probeIntervalInSeconds: 60
+    }
+    sessionAffinityState: 'Disabled'
+  }
+}
+
+resource apiOrigin 'Microsoft.Cdn/profiles/originGroups/origins@2024-02-01' = {
+  parent: apiOriginGroup
+  name: apiOriginName
+  properties: {
+    hostName: apiOriginHostname
+    httpPort: 80
+    httpsPort: 443
+    originHostHeader: apiOriginHostname
+    priority: 1
+    weight: 1000
+    enabledState: 'Enabled'
+  }
+}
+
+resource apiCustomDomain 'Microsoft.Cdn/profiles/customDomains@2024-02-01' = {
+  parent: profile
+  name: 'api-oxyniti-com'
+  properties: {
+    hostName: apiSubdomain
+    tlsSettings: {
+      certificateType: 'ManagedCertificate'
+      minimumTlsVersion: 'TLS12'
+    }
+  }
+}
+
+resource apiRoute 'Microsoft.Cdn/profiles/afdEndpoints/routes@2024-02-01' = {
+  parent: endpoint
+  name: apiRouteName
+  dependsOn: [
+    apiOrigin
+  ]
+  properties: {
+    originGroup: {
+      id: apiOriginGroup.id
+    }
+    customDomains: [
+      {
+        id: apiCustomDomain.id
+      }
+    ]
+    supportedProtocols: [
+      'Http'
+      'Https'
+    ]
+    patternsToMatch: [
+      '/*'
+    ]
+    forwardingProtocol: 'HttpsOnly'
+    linkToDefaultDomain: 'Enabled'
+    httpsRedirect: 'Enabled'
+    enabledState: 'Enabled'
+    // No cacheConfiguration here on purpose -- GetBusinessInfo and friends
+    // are dynamic CMS reads, not static assets. This route only buys the
+    // nearby-PoP TLS handshake + Microsoft backbone hop to UK South, not
+    // caching.
+  }
+}
+
 output frontDoorEndpointHostname string = endpoint.properties.hostName
 output apexDomainValidationToken string = apexCustomDomain.properties.validationProperties.validationToken
 output wwwDomainValidationToken string = wwwCustomDomain.properties.validationProperties.validationToken
+output apiDomainValidationToken string = apiCustomDomain.properties.validationProperties.validationToken

--- a/infra/frontdoor.bicep
+++ b/infra/frontdoor.bicep
@@ -1,0 +1,171 @@
+// Azure Front Door Standard in front of the existing Static Web App.
+//
+// Fixes issue #36: static assets currently go straight to the Static Web
+// App's default hostname with no edge cache in front of it, so every byte
+// travels from wherever SWA's Traffic Manager happens to route the request
+// (measured as Hong Kong for Indian visitors) instead of a nearby PoP, and
+// nothing is ever served from cache (no x-azure-ref / age headers).
+//
+// This template is NOT applied by any pipeline in this repo. Deploy it
+// yourself with the Azure CLI once you've reviewed it — see infra/README.md.
+//
+// Not covered here (see infra/README.md "Not included"):
+//   - the apex-domain (oxyniti.com, no "www") insecure HTTP forward, which
+//     is a registrar-level domain-forwarding setting, not an Azure resource
+//   - a second region for the maker-rest-api backend (owned by a different
+//     repo/service)
+//   - WAF (requires the Premium SKU, not provisioned here to keep cost down)
+
+@description('Default hostname of the Static Web App, e.g. delightful-flower-0fedcf103.3.azurestaticapps.net. Found via `az staticwebapp show`.')
+param staticWebAppDefaultHostname string
+
+@description('Apex domain, e.g. oxyniti.com')
+param apexDomain string = 'oxyniti.com'
+
+@description('www subdomain, e.g. www.oxyniti.com')
+param wwwDomain string = 'www.oxyniti.com'
+
+@description('Front Door profile name.')
+param profileName string = 'oxyniti-fd'
+
+@description('Front Door SKU. Standard gets global PoPs + HTTP/3 + edge caching. Premium adds WAF + Private Link, at extra cost.')
+@allowed([
+  'Standard_AzureFrontDoor'
+  'Premium_AzureFrontDoor'
+])
+param skuName string = 'Standard_AzureFrontDoor'
+
+var endpointName = '${profileName}-ep'
+var originGroupName = 'swa-origin-group'
+var originName = 'swa-origin'
+var routeName = 'default-route'
+
+resource profile 'Microsoft.Cdn/profiles@2024-02-01' = {
+  name: profileName
+  location: 'global'
+  sku: {
+    name: skuName
+  }
+}
+
+resource endpoint 'Microsoft.Cdn/profiles/afdEndpoints@2024-02-01' = {
+  parent: profile
+  name: endpointName
+  location: 'global'
+  properties: {
+    enabledState: 'Enabled'
+    // HTTP/3 (QUIC) is negotiated automatically by Front Door Standard/Premium
+    // endpoints for clients that support it -- there is no separate toggle.
+  }
+}
+
+resource originGroup 'Microsoft.Cdn/profiles/originGroups@2024-02-01' = {
+  parent: profile
+  name: originGroupName
+  properties: {
+    loadBalancingSettings: {
+      sampleSize: 4
+      successfulSamplesRequired: 3
+    }
+    healthProbeSettings: {
+      probePath: '/'
+      probeRequestType: 'HEAD'
+      probeProtocol: 'Https'
+      probeIntervalInSeconds: 60
+    }
+    sessionAffinityState: 'Disabled'
+  }
+}
+
+resource origin 'Microsoft.Cdn/profiles/originGroups/origins@2024-02-01' = {
+  parent: originGroup
+  name: originName
+  properties: {
+    hostName: staticWebAppDefaultHostname
+    httpPort: 80
+    httpsPort: 443
+    originHostHeader: staticWebAppDefaultHostname
+    priority: 1
+    weight: 1000
+    enabledState: 'Enabled'
+  }
+}
+
+resource apexCustomDomain 'Microsoft.Cdn/profiles/customDomains@2024-02-01' = {
+  parent: profile
+  name: 'oxyniti-com'
+  properties: {
+    hostName: apexDomain
+    tlsSettings: {
+      certificateType: 'ManagedCertificate'
+      minimumTlsVersion: 'TLS12'
+    }
+  }
+}
+
+resource wwwCustomDomain 'Microsoft.Cdn/profiles/customDomains@2024-02-01' = {
+  parent: profile
+  name: 'www-oxyniti-com'
+  properties: {
+    hostName: wwwDomain
+    tlsSettings: {
+      certificateType: 'ManagedCertificate'
+      minimumTlsVersion: 'TLS12'
+    }
+  }
+}
+
+resource route 'Microsoft.Cdn/profiles/afdEndpoints/routes@2024-02-01' = {
+  parent: endpoint
+  name: routeName
+  dependsOn: [
+    origin
+  ]
+  properties: {
+    originGroup: {
+      id: originGroup.id
+    }
+    customDomains: [
+      {
+        id: apexCustomDomain.id
+      }
+      {
+        id: wwwCustomDomain.id
+      }
+    ]
+    supportedProtocols: [
+      'Http'
+      'Https'
+    ]
+    patternsToMatch: [
+      '/*'
+    ]
+    forwardingProtocol: 'HttpsOnly'
+    linkToDefaultDomain: 'Enabled'
+    httpsRedirect: 'Enabled'
+    enabledState: 'Enabled'
+    // The origin (Static Web App, via staticwebapp.config.json) already sets
+    // Cache-Control per file type -- Front Door honors those and caches
+    // accordingly. UseQueryString so the ?v=2 cache-buster on /oxyniti.png
+    // keeps working instead of being collapsed away.
+    cacheConfiguration: {
+      queryStringCachingBehavior: 'UseQueryString'
+      compressionSettings: {
+        isCompressionEnabled: true
+        contentTypesToCompress: [
+          'text/html'
+          'text/css'
+          'text/javascript'
+          'application/javascript'
+          'application/json'
+          'application/wasm'
+          'image/svg+xml'
+        ]
+      }
+    }
+  }
+}
+
+output frontDoorEndpointHostname string = endpoint.properties.hostName
+output apexDomainValidationToken string = apexCustomDomain.properties.validationProperties.validationToken
+output wwwDomainValidationToken string = wwwCustomDomain.properties.validationProperties.validationToken


### PR DESCRIPTION
## Summary
- Adds `infra/frontdoor.bicep`: Azure Front Door Standard in front of the existing Static Web App (origin group, route with HTTPS-only + compression + query-string-aware caching, custom domain resources for `oxyniti.com` / `www.oxyniti.com`)
- Adds `infra/README.md`: deploy steps and the DNS changes needed at the registrar to actually cut traffic over, including fixing an unrelated bug found while investigating: the apex domain `oxyniti.com` currently 301-redirects to `http://oxyniti.com` (HTTPS→HTTP downgrade) via registrar-level forwarding, not through Azure at all

Part of #36. Not a full fix by itself — merging this doesn't deploy anything or change production. No pipeline in this repo applies Bicep; someone with Azure + registrar access needs to run the deploy + DNS steps in the README.

Not covered (see README "Not included"): WAF (Premium-tier only), a second region for the `maker-rest-api` backend (lives in a different repo).

## Test plan
- [ ] `az bicep build` / `az deployment group validate` against the template (I don't have Azure CLI available to run this myself — please validate before applying)
- [ ] After deploying + DNS cutover: `curl -I https://www.oxyniti.com` shows `x-azure-ref` and an `age` header on a repeat request
- [ ] `curl -I https://oxyniti.com` returns a clean HTTPS response instead of the HTTP-downgrade redirect