### PR TITLE
perf: make the rest of the static assets edge-cacheable (#36)

### DIFF
--- a/scripts/verify-edge.sh
+++ b/scripts/verify-edge.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+# Checks the acceptance criteria of
+# https://github.com/revred/Oxiniti/issues/36 against a live host: is a CDN
+# actually in front, is it holding the assets, and is HTTP/3 negotiated.
+#
+# The cacheability half of #36 lives in wwwroot/staticwebapp.config.json and
+# ships with the app. The edge half is provisioned outside this repo (Azure
+# Front Door / Cloudflare), so this script is how you tell whether that side
+# has landed -- run it before the cutover for a baseline, and after.
+#
+# Usage:
+#   scripts/verify-edge.sh                      # defaults to www.oxyniti.com
+#   scripts/verify-edge.sh oxyniti.com
+#
+# Exit codes:
+#   0  every #36 criterion met
+#   1  cacheability regressed (a static asset is short-cached again)
+#   2  cacheability fine, but no edge is in front yet (the expected state
+#      until Front Door is provisioned -- see issue #36)
+
+set -uo pipefail
+
+HOST="${1:-www.oxyniti.com}"
+BASE="https://$HOST"
+
+# Paths that must survive at the edge, with the minimum max-age each should
+# carry. Keep in sync with wwwroot/staticwebapp.config.json.
+CACHED_PATHS=(
+  "/_framework/blazor.webassembly.js:31536000"
+  "/images/hero-poster.avif:2592000"
+  "/videos/hero.mp4:2592000"
+  "/bootstrap/dist/css/bootstrap.min.css:2592000"
+  "/vendor/leaflet/leaflet.js:2592000"
+  "/oxyniti.png:2592000"
+  "/app.css:3600"
+  "/Oxyniti.styles.css:3600"
+  "/css/content-pages.css:3600"
+  "/js/scrollHelper.js:3600"
+  "/i18n/translations.json:3600"
+)
+
+# Paths that must NOT be cached long -- the shell and the API config.
+UNCACHED_PATHS=("/" "/appsettings.json")
+
+EDGE_HEADERS="x-azure-ref|cf-ray|x-cache|x-fd-|via|age"
+
+fail_cache=0
+fail_edge=0
+
+hdr() { curl -sSI --max-time 25 "$1" 2>/dev/null | tr -d '\r'; }
+field() { grep -i "^$2:" <<<"$1" | head -1 | cut -d' ' -f2-; }
+
+echo "== $BASE =="
+echo
+
+echo "-- cacheable assets (issue #36: the edge needs something worth holding) --"
+for entry in "${CACHED_PATHS[@]}"; do
+  path="${entry%:*}"; want="${entry##*:}"
+  h="$(hdr "$BASE$path")"
+  status="$(head -1 <<<"$h" | awk '{print $2}')"
+  cc="$(field "$h" Cache-Control)"
+  got="$(grep -oE 'max-age=[0-9]+' <<<"$cc" | head -1 | cut -d= -f2)"
+  if [ "$status" != "200" ]; then
+    printf '  %-42s MISSING (HTTP %s)\n' "$path" "${status:-no response}"
+    fail_cache=1
+  elif [ -z "$got" ] || [ "$got" -lt "$want" ]; then
+    printf '  %-42s FAIL  max-age=%s (want >= %s)\n' "$path" "${got:-none}" "$want"
+    fail_cache=1
+  else
+    printf '  %-42s ok    max-age=%s\n' "$path" "$got"
+  fi
+done
+echo
+
+echo "-- must stay revalidating --"
+for path in "${UNCACHED_PATHS[@]}"; do
+  cc="$(field "$(hdr "$BASE$path")" Cache-Control)"
+  age="$(grep -oE 'max-age=[0-9]+' <<<"$cc" | head -1 | cut -d= -f2)"
+  # Anything up to a minute is fine here; what must not happen is these two
+  # picking up the long TTLs the asset routes carry.
+  if grep -qE 'no-store|no-cache' <<<"$cc" || { [ -n "$age" ] && [ "$age" -le 60 ]; }; then
+    printf '  %-42s ok    %s\n' "$path" "$cc"
+  else
+    printf '  %-42s FAIL  %s\n' "$path" "${cc:-none}"
+    fail_cache=1
+  fi
+done
+echo
+
+echo "-- Vary (shared caches must key on encoding) --"
+v="$(field "$(hdr "$BASE/app.css")" Vary)"
+if grep -qi 'accept-encoding' <<<"$v"; then
+  printf '  ok    Vary: %s\n' "$v"
+else
+  printf '  FAIL  Vary: %s\n' "${v:-missing}"
+  fail_cache=1
+fi
+echo
+
+echo "-- edge presence (provisioned outside this repo) --"
+h1="$(hdr "$BASE/images/hero-poster.avif")"
+h2="$(hdr "$BASE/images/hero-poster.avif")"
+found="$(grep -iE "^($EDGE_HEADERS)" <<<"$h1$h2" | sort -u)"
+if [ -n "$found" ]; then
+  sed 's/^/  /' <<<"$found"
+  if grep -qiE '^age:' <<<"$h2"; then
+    echo "  ok    age present on the repeat request -- the edge is serving from cache"
+  else
+    echo "  WARN  edge headers present but no age on repeat -- cache may be bypassed"
+    fail_edge=1
+  fi
+else
+  echo "  FAIL  no x-azure-ref / cf-ray / x-cache / via / age -- every byte is"
+  echo "        still served from the origin. This is issue #36's headline"
+  echo "        finding and needs Front Door (or Cloudflare) provisioning."
+  fail_edge=1
+fi
+echo
+
+echo "-- negotiated protocol --"
+if curl --version | grep -qi 'HTTP3'; then
+  v3="$(curl -sS --http3 -o /dev/null -w '%{http_version}' --max-time 25 "$BASE/" 2>/dev/null)"
+  echo "  http3 attempt: ${v3:-refused}"
+else
+  echo "  (this curl has no HTTP/3 support -- cannot test; check in a browser)"
+fi
+if curl --version | grep -qi 'HTTP2'; then
+  echo "  default:       $(curl -sS -o /dev/null -w '%{http_version}' --max-time 25 "$BASE/" 2>/dev/null)"
+else
+  echo "  (this curl has no HTTP/2 support -- the version below is not meaningful)"
+fi
+alt="$(field "$(hdr "$BASE/")" alt-svc)"
+[ -n "$alt" ] && echo "  alt-svc:       $alt" || echo "  alt-svc:       none advertised (no HTTP/3 upgrade offered)"
+echo
+
+echo "-- ttfb --"
+curl -sS -o /dev/null -w '  %{time_starttransfer}s (dns %{time_namelookup}s, tls %{time_appconnect}s)\n' \
+  --max-time 25 "$BASE/" 2>/dev/null
+echo
+
+if [ "$fail_cache" -ne 0 ]; then
+  echo "RESULT: cacheability regressed -- fix wwwroot/staticwebapp.config.json first."
+  exit 1
+fi
+if [ "$fail_edge" -ne 0 ]; then
+  echo "RESULT: assets are cacheable, but no CDN is in front yet (issue #36 still open)."
+  exit 2
+fi
+echo "RESULT: all of issue #36's acceptance criteria are met."

--- a/wwwroot/staticwebapp.config.json
+++ b/wwwroot/staticwebapp.config.json
@@ -3,11 +3,21 @@
     "rewrite": "/index.html",
     "exclude": [
       "/favicon.ico",
-      "/images/*",
-      "/js/*",
-      "/bootstrap/*",
+      "/robots.txt",
+      "/sitemap.xml",
       "/app.css",
-      "/icon-192.png"
+      "/Oxyniti.styles.css",
+      "/appsettings.json",
+      "/oxyniti.png",
+      "/icon-192.png",
+      "/_framework/*",
+      "/images/*",
+      "/videos/*",
+      "/js/*",
+      "/css/*",
+      "/vendor/*",
+      "/i18n/*",
+      "/bootstrap/*"
     ]
   },
   "mimeTypes": {
@@ -16,7 +26,11 @@
     ".avif": "image/avif",
     ".webp": "image/webp",
     ".wasm": "application/wasm",
-    ".json": "application/json"
+    ".json": "application/json",
+    ".ico": "image/x-icon",
+    ".svg": "image/svg+xml",
+    ".woff": "font/woff",
+    ".woff2": "font/woff2"
   },
   "globalHeaders": {
     "Vary": "Accept-Encoding"
@@ -24,9 +38,21 @@
   "routes": [
     { "route": "/_framework/blazor.boot.json", "headers": { "Cache-Control": "public, max-age=0, must-revalidate" } },
     { "route": "/_framework/*", "headers": { "Cache-Control": "public, max-age=31536000, immutable" } },
+    { "route": "/appsettings.json", "headers": { "Cache-Control": "public, max-age=0, must-revalidate" } },
     { "route": "/images/*", "headers": { "Cache-Control": "public, max-age=2592000" } },
     { "route": "/videos/*", "headers": { "Cache-Control": "public, max-age=2592000" } },
     { "route": "/bootstrap/*", "headers": { "Cache-Control": "public, max-age=2592000" } },
+    { "route": "/vendor/*", "headers": { "Cache-Control": "public, max-age=2592000" } },
+    { "route": "/oxyniti.png", "headers": { "Cache-Control": "public, max-age=2592000" } },
+    { "route": "/icon-192.png", "headers": { "Cache-Control": "public, max-age=2592000" } },
+    { "route": "/favicon.ico", "headers": { "Cache-Control": "public, max-age=2592000" } },
+    { "route": "/js/*", "headers": { "Cache-Control": "public, max-age=3600, must-revalidate" } },
+    { "route": "/css/*", "headers": { "Cache-Control": "public, max-age=3600, must-revalidate" } },
+    { "route": "/i18n/*", "headers": { "Cache-Control": "public, max-age=3600, must-revalidate" } },
+    { "route": "/app.css", "headers": { "Cache-Control": "public, max-age=3600, must-revalidate" } },
+    { "route": "/Oxyniti.styles.css", "headers": { "Cache-Control": "public, max-age=3600, must-revalidate" } },
+    { "route": "/robots.txt", "headers": { "Cache-Control": "public, max-age=3600" } },
+    { "route": "/sitemap.xml", "headers": { "Cache-Control": "public, max-age=3600" } },
     { "route": "/index.html", "headers": { "Cache-Control": "public, max-age=0, must-revalidate" } }
   ]
 }


### PR DESCRIPTION
## Summary

Part of #36. Measured live against production on 26 Aug 2026 — after #29/#51 landed, only the routed prefixes picked up long TTLs. Everything else still came back `Cache-Control: public, must-revalidate, max-age=30`:

| path | before | after |
|---|---|---|
| `/app.css` | 30 s | 1 h + revalidate |
| `/Oxyniti.styles.css` | 30 s | 1 h + revalidate |
| `/css/content-pages.css` | 30 s | 1 h + revalidate |
| `/js/*` | 30 s | 1 h + revalidate |
| `/i18n/translations.json` | 30 s | 1 h + revalidate |
| `/vendor/*` (Leaflet, QR — self-hosted in #49) | 30 s | 30 d |
| `/oxyniti.png`, `/icon-192.png` | 30 s | 30 d |
| `/robots.txt`, `/sitemap.xml` | 30 s | 1 h |
| `/appsettings.json` | 30 s | 0 + revalidate |

That is every stylesheet and script in `index.html`'s `<head>` except bootstrap, plus the translation bundle. #36 turns on those assets being worth holding at an edge — with a 30-second TTL a CDN revalidates to UK South on nearly every visit, and #36's "`age` header on repeat requests" criterion could never pass.

## TTLs are tiered by how the file changes

- **30 days** — vendored or media that only changes by a deliberate file swap (`/vendor/*`, root logo + icon). Same policy `/bootstrap/*` and `/images/*` already carry.
- **1 hour + `must-revalidate`** — app-owned CSS/JS/translations. These filenames are **not** fingerprinted, so a 30-day TTL would strand visitors on stale app code after a deploy. An hour of real edge cache followed by a cheap 304 is the safe trade until they are content-hashed.
- **0 + `must-revalidate`** — `/appsettings.json`. It carries `RampEdge.BaseAddress`, which #53 step 4 will repoint at `api.oxyniti.com`; caching it long would strand clients on the old API host.

## Also

- Widens `navigationFallback.exclude` to cover `/css`, `/vendor`, `/i18n`, `/videos`, `/_framework`. Without those, a request for a **missing** asset returned `index.html` with a **200** instead of a 404 — harmless from the origin, but an edge would cache an HTML body under an asset URL.
- Adds `.ico` / `.svg` / `.woff` / `.woff2` MIME types alongside the ones #51 added.
- Adds `scripts/verify-edge.sh` — checks #36's acceptance criteria against a live host (cacheability, `Vary`, edge headers, `age` on repeat, negotiated protocol, TTFB). Exits **1** if cacheability regressed, **2** while no CDN is in front (the expected state today), **0** when #36 is fully met.

## Test plan

Verified through the Static Web Apps emulator, then re-verified against this PR's real SWA preview deployment:

- [x] Every route resolves to its intended `Cache-Control` — all 17 paths checked
- [x] `Vary: Accept-Encoding` on every response
- [x] SPA routes (`/about`, `/technology`, `/contact`, deep routes) still fall back to `index.html` with 200
- [x] Missing assets under the newly-excluded prefixes now return **404** instead of a 200 HTML body
- [x] `staticwebapp.config.json` lands at the site root of the publish output, byte-identical to source
- [x] Verified on this PR's SWA preview deployment: `scripts/verify-edge.sh` exits **2** — cacheability clean, edge still absent ([evidence](https://github.com/revred/Oxiniti/pull/54#issuecomment-5423827254))

## What this does *not* do

**Does not close #36.** Items 1, 2 and 5 — provisioning Front Door / Cloudflare, enabling HTTP/3, and a second API region — need Azure and registrar access that does not exist in this repo. This PR is the prerequisite the issue itself calls out: *"an edge is only useful if assets are cacheable."*

🤖 Generated with [Claude Code](https://claude.com/claude-code)


