### PR TITLE
Simplify FAQ section to a single heading

### DIFF
--- a/Pages/Components/FAQSection.razor
+++ b/Pages/Components/FAQSection.razor
@@ -1,9 +1,7 @@
 @inject LocalizationService Loc
 
 <div class="faq-section" id="faq">
-    <span class="kicker">@Loc.T("faq.kicker", "Frequently asked questions")</span>
-    <h2 class="section-title">@Loc.T("faq.title", "Still have questions?")</h2>
-    <p class="section-lead">@Loc.T("faq.lead", "Everything farmers usually ask us before their first demo.")</p>
+    <h2 class="section-title">@Loc.T("faq.kicker", "Frequently asked questions")</h2>
 
     <div class="faq-list">
         @for (var i = 0; i < Faqs.Count; i++)

--- a/Pages/Components/FAQSection.razor.css
+++ b/Pages/Components/FAQSection.razor.css
@@ -2,28 +2,10 @@
     padding: 1rem 0 3rem;
 }
 
-.kicker {
-    display: inline-block;
-    font-size: 0.8rem;
-    font-weight: 700;
-    letter-spacing: 0.06em;
-    text-transform: uppercase;
-    color: #3D8FB5;
-    margin-bottom: 0.75rem;
-}
-
 .section-title {
     color: #1A2C54;
     font-size: 2.25rem;
     font-weight: 600;
-    margin-bottom: 0.75rem;
-}
-
-.section-lead {
-    max-width: 640px;
-    color: #3a3a3a;
-    font-size: 1.05rem;
-    line-height: 1.6;
     margin-bottom: 2rem;
 }
 


### PR DESCRIPTION
Drops the redundant "Still have questions?" title and lead sentence, keeping just "Frequently asked questions" as the section's one heading. Reuses the existing faq.kicker translation key (already holds that exact phrase in every supported language) instead of introducing new strings.