### PR TITLE
Fix testimonial hover cursor showing as a question mark

### DIFF
--- a/Pages/Components/Testimonials.razor.css
+++ b/Pages/Components/Testimonials.razor.css
@@ -46,7 +46,7 @@
 }
 
 ::deep .testimonial-quote--translatable {
-    cursor: help;
+    cursor: pointer;
     text-decoration: underline dotted rgba(255, 255, 255, 0.6);
     text-underline-offset: 4px;
 }


### PR DESCRIPTION
## Summary
- Translatable testimonial text used `cursor: help`, which shows a question-mark cursor icon on hover and was reported as a rendering glitch
- Changed to `cursor: pointer` in `Pages/Components/Testimonials.razor.css` — the dotted underline still signals the hover-translate affordance

## Test plan
- [ ] Hover a non-Latin-script testimonial (e.g. Tamil) on the site and confirm the cursor no longer shows a "?" icon while the translation tooltip still appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)