### PR TITLE
perf: drop ICU globalization data from WASM payload

### DIFF
--- a/Oxyniti.csproj
+++ b/Oxyniti.csproj
@@ -26,6 +26,15 @@
     <HttpActivityPropagationSupport>false</HttpActivityPropagationSupport>
 
     <!--
+      Drops the ICU dataset (issue #35, item 1). LocalizationService owns all
+      user-facing translation and every date/money format in the app already
+      uses an explicit format string ("dd/MM/yyyy", "N2") with either the
+      invariant culture or invariant-safe format specifiers, so there is no
+      culture-dependent formatting left for ICU to serve.
+    -->
+    <InvariantGlobalization>true</InvariantGlobalization>
+
+    <!--
       Source-generate the binder for the three BindConfiguration calls in
       Program.cs.
 


### PR DESCRIPTION
## Summary
- Adds `InvariantGlobalization=true` to `Oxyniti.csproj`, dropping all three ICU shards (`icudt_CJK`, `icudt_EFIGS`, `icudt_no_CJK`) from `blazor.boot.json`.
- Verified with a Release publish: `_framework` brotli payload drops from 3.28 MB to 2.64 MB (~643 KB, ~20%), well under the CI budget of 3,405,591 bytes.
- Safe because `LocalizationService` owns all user-facing translation, and every date/money format in the app (`Orders.razor`, `ProfitCalculatorSection.razor`, etc.) already uses an explicit format string with either `CultureInfo.InvariantCulture` or an invariant-safe specifier — there's no culture-dependent formatting left for ICU to serve.

Closes #35 (items 2 and 5 from that issue — full trimming and lazy-loaded assemblies — are intentionally not part of this PR; tracked as a follow-up).

## Test plan
- [x] `dotnet publish -c Release` succeeds
- [x] Confirmed `icudt*.dat` absent from publish output and `blazor.boot.json`
- [x] Confirmed new payload size is under the CI `_framework` budget
- [ ] Manual smoke test in a browser (cart, checkout, language switch, order dates) before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)