### PR TITLE
Improve perceived drone quality without increasing video size

### DIFF
--- a/Pages/Components/SkyViewSection.razor
+++ b/Pages/Components/SkyViewSection.razor
@@ -11,10 +11,18 @@
     </p>
 
     <div class="drone-stage">
-        <video @ref="_videoElement" muted loop playsinline poster="/images/drone-poster.jpg">
+        <canvas @ref="_backdropCanvas" class="drone-stage-backdrop" aria-hidden="true"></canvas>
+        <video @ref="_videoElement"
+               class="drone-stage-video"
+               muted
+               loop
+               playsinline
+               preload="none"
+               poster="/images/drone-poster.jpg">
             <source data-src="/videos/drone.webm" type="video/webm" />
             <source data-src="/videos/drone.mp4" type="video/mp4" />
         </video>
+        <div class="drone-stage-grade" aria-hidden="true"></div>
         <div class="rec-badge"><i></i><span>@Loc.T("sky.rec", "DRONE · LIVE TRIAL")</span></div>
         <div class="hud-chips">
             <div class="hud-chip"><span class="dot"></span>@Loc.T("sky.c1", "Unit 1 · nano-plume active")</div>
@@ -26,8 +34,9 @@
 
 @code {
     private ElementReference _videoElement;
-    private IJSObjectReference? _videoModule;
-    private IJSObjectReference? _videoController;
+    private ElementReference _backdropCanvas;
+    private IJSObjectReference? _droneModule;
+    private IJSObjectReference? _droneController;
 
     protected override void OnInitialized()
     {
@@ -41,19 +50,18 @@
 
         try
         {
-            _videoModule = await JS.InvokeAsync<IJSObjectReference>(
+            _droneModule = await JS.InvokeAsync<IJSObjectReference>(
                 "import",
-                "./js/lazyBackgroundVideo.js");
+                "./js/droneStage.js");
 
-            _videoController = await _videoModule.InvokeAsync<IJSObjectReference>(
+            _droneController = await _droneModule.InvokeAsync<IJSObjectReference>(
                 "init",
                 _videoElement,
-                null,
-                new { eager = false });
+                _backdropCanvas);
         }
         catch (JSException)
         {
-            // Prevent page from breaking if JS is unavailable.
+            // Keep the poster treatment visible if JavaScript is unavailable.
         }
     }
 
@@ -63,20 +71,20 @@
 
         try
         {
-            if (_videoController is not null)
+            if (_droneController is not null)
             {
-                await _videoController.InvokeVoidAsync("dispose");
-                await _videoController.DisposeAsync();
+                await _droneController.InvokeVoidAsync("dispose");
+                await _droneController.DisposeAsync();
             }
 
-            if (_videoModule is not null)
+            if (_droneModule is not null)
             {
-                await _videoModule.DisposeAsync();
+                await _droneModule.DisposeAsync();
             }
         }
         catch (JSDisconnectedException)
         {
-            // Safe to ignore when Blazor circuit disconnects.
+            // Safe to ignore when Blazor disconnects during navigation.
         }
     }
 }

--- a/Pages/Components/SkyViewSection.razor.css
+++ b/Pages/Components/SkyViewSection.razor.css
@@ -29,6 +29,7 @@
 
 .drone-stage {
     position: relative;
+    isolation: isolate;
     border-radius: 1rem;
     overflow: hidden;
     min-height: 420px;
@@ -36,18 +37,91 @@
     box-shadow: 0 4px 10px rgba(0, 0, 0, 0.2);
 }
 
-.drone-stage video {
+/*
+ * The compact 480 x 500 source is kept close to native scale in the centre.
+ * Its existing poster fills the sides only as a deliberately soft background,
+ * so enlargement artifacts become atmosphere rather than visible detail.
+ */
+.drone-stage::before {
+    content: "";
+    position: absolute;
+    inset: -8%;
+    z-index: 0;
+    background: url('/images/drone-poster.jpg') center / cover no-repeat;
+    filter: blur(24px) saturate(1.15) brightness(0.58);
+    transform: scale(1.08);
+}
+
+.drone-stage-backdrop {
+    position: absolute;
+    inset: -8%;
+    z-index: 1;
+    width: 116%;
+    height: 116%;
+    object-fit: cover;
+    opacity: 0;
+    filter: blur(26px) saturate(1.18) brightness(0.58);
+    transform: scale(1.08);
+    transition: opacity 0.45s ease;
+}
+
+.drone-stage-backdrop.is-active {
+    opacity: 0.94;
+}
+
+.drone-stage-video {
+    position: absolute;
+    top: 2%;
+    left: 50%;
+    z-index: 2;
+    height: 96%;
+    width: auto;
+    max-width: 100%;
+    aspect-ratio: 480 / 500;
+    object-fit: cover;
+    border-radius: 0.45rem;
+    opacity: 0.96;
+    transform: translateX(-50%);
+    filter: contrast(1.08) saturate(0.9) brightness(0.96);
+    box-shadow:
+        0 0 0 1px rgba(213, 244, 255, 0.18),
+        0 0 64px rgba(2, 14, 28, 0.62);
+    transition: opacity 0.45s ease, filter 0.45s ease;
+}
+
+.drone-stage-video.is-visible {
+    opacity: 1;
+    filter: contrast(1.09) saturate(0.92) brightness(0.98);
+}
+
+/* Matches the restrained blue grade used by the homepage hero. */
+.drone-stage-grade {
     position: absolute;
     inset: 0;
-    width: 100%;
-    height: 100%;
-    object-fit: cover;
+    z-index: 3;
+    pointer-events: none;
+    background:
+        radial-gradient(circle at 50% 46%, rgba(61, 143, 181, 0.04) 0%, rgba(11, 31, 51, 0.18) 54%, rgba(2, 13, 25, 0.62) 100%),
+        linear-gradient(180deg, rgba(61, 143, 181, 0.2) 0%, rgba(11, 31, 51, 0.34) 100%);
+}
+
+/* Very light dithering breaks up visible block boundaries without another asset. */
+.drone-stage::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    z-index: 4;
+    pointer-events: none;
+    opacity: 0.045;
+    mix-blend-mode: soft-light;
+    background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 180 180' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='noise'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='.78' numOctaves='2' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23noise)' opacity='.62'/%3E%3C/svg%3E");
 }
 
 .rec-badge {
     position: absolute;
     top: 1rem;
     left: 1rem;
+    z-index: 5;
     display: flex;
     align-items: center;
     gap: 0.5rem;
@@ -58,6 +132,7 @@
     font-size: 0.75rem;
     font-weight: 600;
     letter-spacing: 0.04em;
+    backdrop-filter: blur(6px);
 }
 
 .rec-badge i {
@@ -72,6 +147,7 @@
     position: absolute;
     bottom: 1rem;
     left: 1rem;
+    z-index: 5;
     display: flex;
     flex-direction: column;
     gap: 0.5rem;
@@ -86,6 +162,7 @@
     padding: 0.4rem 0.75rem;
     border-radius: 2rem;
     font-size: 0.8rem;
+    backdrop-filter: blur(6px);
 }
 
 .hud-chip .dot {
@@ -99,5 +176,17 @@
 @media (max-width: 768px) {
     .drone-stage {
         min-height: 260px;
+    }
+
+    .drone-stage-video {
+        top: 3%;
+        height: 94%;
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .drone-stage-backdrop,
+    .drone-stage-video {
+        transition: none;
     }
 }

--- a/wwwroot/js/droneStage.js
+++ b/wwwroot/js/droneStage.js
@@ -1,0 +1,138 @@
+import { init as initLazyVideo } from "./lazyBackgroundVideo.js";
+
+const BACKDROP_WIDTH = 160;
+const BACKDROP_HEIGHT = 90;
+const MIN_FRAME_INTERVAL_MS = 80;
+
+function drawCover(context, video, targetWidth, targetHeight) {
+    if (video.readyState < HTMLMediaElement.HAVE_CURRENT_DATA || !video.videoWidth || !video.videoHeight) {
+        return false;
+    }
+
+    const sourceRatio = video.videoWidth / video.videoHeight;
+    const targetRatio = targetWidth / targetHeight;
+
+    let sourceX = 0;
+    let sourceY = 0;
+    let sourceWidth = video.videoWidth;
+    let sourceHeight = video.videoHeight;
+
+    if (sourceRatio > targetRatio) {
+        sourceWidth = video.videoHeight * targetRatio;
+        sourceX = (video.videoWidth - sourceWidth) / 2;
+    } else {
+        sourceHeight = video.videoWidth / targetRatio;
+        sourceY = (video.videoHeight - sourceHeight) / 2;
+    }
+
+    context.drawImage(
+        video,
+        sourceX,
+        sourceY,
+        sourceWidth,
+        sourceHeight,
+        0,
+        0,
+        targetWidth,
+        targetHeight
+    );
+
+    return true;
+}
+
+export function init(video, backdropCanvas) {
+    if (!video || !backdropCanvas) {
+        throw new Error("The drone video and backdrop canvas are required.");
+    }
+
+    const lazyController = initLazyVideo(video, null, { eager: false });
+    const context = backdropCanvas.getContext("2d", {
+        alpha: false,
+        desynchronized: true
+    });
+
+    if (!context) {
+        return {
+            dispose() {
+                lazyController.dispose();
+            }
+        };
+    }
+
+    backdropCanvas.width = BACKDROP_WIDTH;
+    backdropCanvas.height = BACKDROP_HEIGHT;
+
+    let disposed = false;
+    let videoFrameRequest = 0;
+    let animationFrameRequest = 0;
+    let lastDrawTime = 0;
+
+    const drawBackdrop = (timestamp = performance.now()) => {
+        if (disposed || timestamp - lastDrawTime < MIN_FRAME_INTERVAL_MS) {
+            return;
+        }
+
+        if (drawCover(context, video, BACKDROP_WIDTH, BACKDROP_HEIGHT)) {
+            lastDrawTime = timestamp;
+            backdropCanvas.classList.add("is-active");
+        }
+    };
+
+    const stopFrameLoop = () => {
+        if (videoFrameRequest && typeof video.cancelVideoFrameCallback === "function") {
+            video.cancelVideoFrameCallback(videoFrameRequest);
+        }
+
+        if (animationFrameRequest) {
+            cancelAnimationFrame(animationFrameRequest);
+        }
+
+        videoFrameRequest = 0;
+        animationFrameRequest = 0;
+    };
+
+    const scheduleFrame = () => {
+        if (disposed || video.paused || video.ended) {
+            return;
+        }
+
+        if (typeof video.requestVideoFrameCallback === "function") {
+            videoFrameRequest = video.requestVideoFrameCallback((timestamp) => {
+                drawBackdrop(timestamp);
+                scheduleFrame();
+            });
+            return;
+        }
+
+        animationFrameRequest = requestAnimationFrame((timestamp) => {
+            drawBackdrop(timestamp);
+            scheduleFrame();
+        });
+    };
+
+    const onPlaying = () => {
+        stopFrameLoop();
+        drawBackdrop();
+        scheduleFrame();
+    };
+
+    const onLoadedData = () => drawBackdrop();
+    const onStopped = () => stopFrameLoop();
+
+    video.addEventListener("playing", onPlaying);
+    video.addEventListener("loadeddata", onLoadedData);
+    video.addEventListener("pause", onStopped);
+    video.addEventListener("ended", onStopped);
+
+    return {
+        dispose() {
+            disposed = true;
+            stopFrameLoop();
+            video.removeEventListener("playing", onPlaying);
+            video.removeEventListener("loadeddata", onLoadedData);
+            video.removeEventListener("pause", onStopped);
+            video.removeEventListener("ended", onStopped);
+            lazyController.dispose();
+        }
+    };
+}


### PR DESCRIPTION
## Preview

https://delightful-flower-0fedcf103-76.westeurope.3.azurestaticapps.net

Scroll to **See it from the sky** to review the treatment.

## What changed

- Keeps the existing compact `drone.webm` / `drone.mp4` files; no new video payloads.
- Stops enlarging the 480×500 source across the full wide stage.
- Displays the sharp footage near native scale in the centre.
- Draws the already-decoded frames into a tiny 160×90 canvas at roughly 12 fps for a blurred moving backdrop, so there is no second video download or second decoder.
- Applies the same restrained blue grade used by the homepage hero.
- Adds very subtle dithering to soften visible compression-block boundaries.
- Preserves the existing lazy-loading and poster-only behaviour on narrow/reduced-data devices.

## Why

The current section uses `object-fit: cover` on a near-square 480×500 file inside a wide 420px-high stage. That magnifies compression artifacts. This change treats enlarged pixels as an intentionally blurred background and keeps the detailed part of the footage downscaled.

## Files

- `Pages/Components/SkyViewSection.razor`
- `Pages/Components/SkyViewSection.razor.css`
- `wwwroot/js/droneStage.js`
