### PR TITLE
SEO quick wins: canonical, JSON-LD, share cards, nav hrefs

### DIFF
--- a/Layout/MainLayout.razor
+++ b/Layout/MainLayout.razor
@@ -115,7 +115,7 @@
                     {
                         <div id="user-menu" class="user-menu">
 
-                            <a href="account"
+                            <a href="/account"
                                class="user-menu-item">
 
                                 <i class="bi bi-person-circle"></i>
@@ -187,7 +187,7 @@
             else
             {
                 <!-- Login -->
-                <a href="login"
+                <a href="/login"
                    class="login-avatar"
                    title="@Loc.T("nav.login", "Login")"
                    aria-label="@Loc.T("nav.login", "Login")">
@@ -213,21 +213,12 @@
 
 </div>
 
-
-<div id="blazor-error-ui" data-nosnippet>
-
-    @Loc.T("err.unhandled", "An unhandled error has occurred.")
-
-    <a href="." class="reload">
-        @Loc.T("err.reload", "Reload")
-    </a>
-
-    <span class="dismiss">
-        🗙
-    </span>
-
-</div>
-
+<!-- #blazor-error-ui lives in wwwroot/index.html, created by inline script
+     before blazor.webassembly.js runs, appended to document.body (outside
+     this component tree). It must NOT be re-declared here: Blazor's runtime
+     finds the id via a live DOM lookup regardless of which document node it
+     lives on, and a second copy inside the app root created a duplicate id
+     in the live DOM. -->
 
 @code {
 
@@ -299,6 +290,15 @@
         if (!string.IsNullOrEmpty(code))
         {
             await Loc.SetLanguageAsync(code);
+
+            try
+            {
+                await JSRuntime.InvokeVoidAsync("oxynitiI18n.setHtmlLang", code);
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"[MainLayout] Error syncing html lang attribute: {ex}");
+            }
         }
     }
 

--- a/Layout/NavMenu.razor
+++ b/Layout/NavMenu.razor
@@ -41,9 +41,12 @@
          onclick="document.getElementById('nav-toggle').checked = false">
 
         <!-- 1. HOME -->
-        <a class="nav-link" 
-           href="#" 
-           data-section="hero" 
+        <!-- Real in-page href so a no-JS fetch or crawler gets a resolvable
+             target instead of a bare "#"; onclick still preventDefaults and
+             drives the smooth-scroll/cross-page logic for real visitors. -->
+        <a class="nav-link"
+           href="/#hero"
+           data-section="hero"
            @onclick='() => GoToHomeSection("hero")'
            @onclick:preventDefault="true">
             @Loc.T("nav.home", "Home")
@@ -54,13 +57,13 @@
              entirely by NavLink's own routing-based active state, not the
              scroll-spy that drives the other (same-page anchor) links. -->
         <NavLink class="nav-link"
-                 href="products">
+                 href="/products">
             @Loc.T("nav.products", "Products")
         </NavLink>
 
         <!-- 3. TECHNOLOGY -->
         <a class="nav-link"
-           href="#"
+           href="/#technology"
            data-section="technology"
            @onclick='() => GoToHomeSection("technology")'
            @onclick:preventDefault="true">
@@ -69,7 +72,7 @@
 
         <!-- 4. RESULTS -->
         <a class="nav-link"
-           href="#"
+           href="/#results"
            data-section="results"
            @onclick='() => GoToHomeSection("results")'
            @onclick:preventDefault="true">
@@ -78,7 +81,7 @@
 
         <!-- 5. FIELD FOOTAGE -->
         <a class="nav-link"
-           href="#"
+           href="/#use-cases"
            data-section="use-cases"
            @onclick='() => GoToHomeSection("use-cases")'
            @onclick:preventDefault="true">
@@ -87,7 +90,7 @@
 
         <!-- 6. CONTACT -->
         <a class="nav-link"
-           href="#"
+           href="/#free-demo"
            data-section="free-demo"
            @onclick='() => GoToHomeSection("free-demo")'
            @onclick:preventDefault="true">

--- a/Pages/About.razor
+++ b/Pages/About.razor
@@ -5,6 +5,7 @@
 
 <PageTitle>@Loc.T("about.pagetitle", "About Oxyniti | Nano-Bubble Aeration")</PageTitle>
 <HeadContent>
+    <link rel="canonical" href="https://www.oxyniti.com/about" />
     <meta name="description" content="@Loc.T("about.meta", "Oxyniti designs and manufactures nano-bubble aeration systems for aquaculture, wastewater treatment and hydroponics, with 100+ installations across India.")" />
 </HeadContent>
 

--- a/Pages/AquacultureOxygenation.razor
+++ b/Pages/AquacultureOxygenation.razor
@@ -3,6 +3,7 @@
 
 <PageTitle>@Loc.T("aqox.pagetitle", "Aquaculture Oxygenation Systems | Oxyniti")</PageTitle>
 <HeadContent>
+    <link rel="canonical" href="https://www.oxyniti.com/aquaculture-oxygenation" />
     <meta name="description" content="@Loc.T("aqox.meta", "Nano-bubble aeration for aquaculture ponds, RAS and biofloc systems — raises dissolved oxygen through the water column, not just the surface, to prevent night-time DO crashes.")" />
 </HeadContent>
 

--- a/Pages/Components/Footer.razor
+++ b/Pages/Components/Footer.razor
@@ -29,6 +29,7 @@
                 <div class="footer-section">
                     <h4>@Loc.T("foot.explore", "Explore")</h4>
                     <ul>
+                        <li><a href="/products">@Loc.T("nav.products", "Products")</a></li>
                         <li><a href="/technology">@Loc.T("nav.tech", "Technology")</a></li>
                         <li><a href="/aquaculture-oxygenation">@Loc.T("nav.aqox", "Aquaculture Oxygenation")</a></li>
                         <li><a href="/ras-oxygenation">@Loc.T("nav.rasox", "RAS &amp; Biofloc")</a></li>
@@ -47,14 +48,24 @@
                     </ul>
                 </div>
 
+                <div class="footer-section">
+                    <h4>@Loc.T("foot.company", "Company")</h4>
+                    <ul>
+                        <li><a href="/about">@Loc.T("nav.about", "About")</a></li>
+                        <li><a href="/contact">@Loc.T("nav.contact", "Contact")</a></li>
+                        <li><a href="/privacy">@Loc.T("nav.privacy", "Privacy Policy")</a></li>
+                        <li><a href="/terms">@Loc.T("nav.terms", "Terms")</a></li>
+                    </ul>
+                </div>
+
                 <div class="footer-section footer-community">
                     <h4>@Loc.T("foot.community", "Community")</h4>
-                    <div class="footer-whatsapp">
+                    <a class="footer-whatsapp" href="@SiteContact.WhatsAppGroupLink" target="_blank" rel="noopener">
                         <WhatsAppGroupQr Size="96" Caption="@null" />
                         <div class="footer-whatsapp-text">
                             <span class="footer-whatsapp-title"><i class="bi bi-whatsapp"></i> @Loc.T("foot.wa.title", "Join our WhatsApp community")</span>
                         </div>
-                    </div>
+                    </a>
                 </div>
             </div>
         </div>

--- a/Pages/Contact.razor
+++ b/Pages/Contact.razor
@@ -3,6 +3,7 @@
 
 <PageTitle>@Loc.T("contact.pagetitle", "Contact Oxyniti")</PageTitle>
 <HeadContent>
+    <link rel="canonical" href="https://www.oxyniti.com/contact" />
     <meta name="description" content="@Loc.T("contact.meta", "Get in touch with Oxyniti — call, WhatsApp, or book a free on-pond demo.")" />
 </HeadContent>
 

--- a/Pages/Home.razor
+++ b/Pages/Home.razor
@@ -2,6 +2,76 @@
 @inject IJSRuntime JS
 
 <PageTitle>Oxyniti - Nano-Bubble Aeration</PageTitle>
+<HeadContent>
+    <link rel="canonical" href="https://www.oxyniti.com/" />
+    <!-- Mirrors FAQSection.razor's questions/answers verbatim -- keep the two
+         in sync; a search engine or answer-engine crawler cross-checks the
+         JSON-LD text against the visible text and penalizes a mismatch. -->
+    <script type="application/ld+json">
+    {
+        "@@context": "https://schema.org",
+        "@@type": "FAQPage",
+        "mainEntity": [
+            {
+                "@@type": "Question",
+                "name": "How does Oxyniti actually raise dissolved oxygen?",
+                "acceptedAnswer": {
+                    "@@type": "Answer",
+                    "text": "Oxyniti dissolves oxygen into the pond as a fine nano-bubble plume instead of just churning the surface like a paddle wheel. The bubbles are small enough to stay suspended and dissolve into the water column, so oxygen reaches the fish even overnight, when algae stop producing oxygen and DO crashes."
+                }
+            },
+            {
+                "@@type": "Question",
+                "name": "How is this different from a paddle wheel aerator?",
+                "acceptedAnswer": {
+                    "@@type": "Answer",
+                    "text": "Paddle wheels mix the surface, but a lot of that oxygen escapes back into the air as fast as it goes in. Oxyniti's nano-bubbles have far more surface area and stay in the water longer, so more of the oxygen you're paying to add actually ends up dissolved."
+                }
+            },
+            {
+                "@@type": "Question",
+                "name": "What results can I expect?",
+                "acceptedAnswer": {
+                    "@@type": "Answer",
+                    "text": "Typical ranges reported in published nano-bubble aquaculture studies and field trials: around 2× higher dissolved oxygen, +15% survival rate, and -15% feed conversion ratio, which opens up roughly +30% stocking density. Actual results vary with species, pond condition and management."
+                }
+            },
+            {
+                "@@type": "Question",
+                "name": "Which species and pond types does it work for?",
+                "acceptedAnswer": {
+                    "@@type": "Answer",
+                    "text": "Tilapia/GIFT, Murrel, Pangasius, freshwater prawn, carp polyculture, and biofloc/RAS systems — on almost any pond, with install completed in about a day."
+                }
+            },
+            {
+                "@@type": "Question",
+                "name": "Can I see it working on my own pond before I commit?",
+                "acceptedAnswer": {
+                    "@@type": "Answer",
+                    "text": "Yes. Our team installs a unit on your pond, measures dissolved oxygen before and after with a calibrated DO meter, and shows you the difference the same day — no obligation."
+                }
+            },
+            {
+                "@@type": "Question",
+                "name": "How do I estimate the profit impact for my pond?",
+                "acceptedAnswer": {
+                    "@@type": "Answer",
+                    "text": "Use the profit calculator further up this page, or the Profit Calc button in the top bar — enter your pond size and species to see an estimate of the extra yield and margin."
+                }
+            },
+            {
+                "@@type": "Question",
+                "name": "Where do you currently install?",
+                "acceptedAnswer": {
+                    "@@type": "Answer",
+                    "text": "We're currently serving Tamil Nadu and South India."
+                }
+            }
+        ]
+    }
+    </script>
+</HeadContent>
 
 <div style="padding:10px;">
     <!-- Wrap Hero with id="hero" so the ScrollSpy picks up "Home" -->

--- a/Pages/Privacy.razor
+++ b/Pages/Privacy.razor
@@ -4,6 +4,9 @@
 @inject LocalizationService Loc
 
 <PageTitle>Privacy Policy - Oxyniti</PageTitle>
+<HeadContent>
+    <link rel="canonical" href="https://www.oxyniti.com/privacy" />
+</HeadContent>
 
 <h2 class="section-title">@Loc.T("privacy.title", "Privacy Policy")</h2>
 

--- a/Pages/Products.razor
+++ b/Pages/Products.razor
@@ -3,7 +3,22 @@
 
 <PageTitle>Oxyniti Products | Nano-Bubble Aeration Systems</PageTitle>
 <HeadContent>
+    <link rel="canonical" href="https://www.oxyniti.com/products" />
     <meta name="description" content="Browse Oxyniti's nano-bubble aeration products for aquaculture ponds, RAS and biofloc systems." />
+    <script type="application/ld+json">
+    {
+        "@@context": "https://schema.org",
+        "@@type": "ProductGroup",
+        "name": "OXY-Nano Series nano-bubble generator",
+        "brand": { "@@type": "Brand", "name": "Oxyniti" },
+        "variesBy": "https://schema.org/size",
+        "hasVariant": [
+            { "@@type": "Product", "name": "OXY-Nano-1.5", "sku": "OXY-NANO-1.5" },
+            { "@@type": "Product", "name": "OXY-Nano-3", "sku": "OXY-NANO-3" },
+            { "@@type": "Product", "name": "OXY-Nano-5", "sku": "OXY-NANO-5" }
+        ]
+    }
+    </script>
 </HeadContent>
 
 <div class="container-fluid px-4 py-5">

--- a/Pages/RasOxygenation.razor
+++ b/Pages/RasOxygenation.razor
@@ -3,6 +3,7 @@
 
 <PageTitle>@Loc.T("rasox.pagetitle", "RAS & Biofloc Oxygenation | Oxyniti")</PageTitle>
 <HeadContent>
+    <link rel="canonical" href="https://www.oxyniti.com/ras-oxygenation" />
     <meta name="description" content="@Loc.T("rasox.meta", "Nano-bubble oxygenation for recirculating aquaculture (RAS) and biofloc systems, where maintaining dissolved oxygen at high stocking density is critical.")" />
 </HeadContent>
 

--- a/Pages/Sitemap.razor
+++ b/Pages/Sitemap.razor
@@ -2,6 +2,9 @@
 @inject LocalizationService Loc
 
 <PageTitle>@Loc.T("sitemap.pagetitle", "Sitemap - Oxyniti")</PageTitle>
+<HeadContent>
+    <link rel="canonical" href="https://www.oxyniti.com/sitemap" />
+</HeadContent>
 
 <h2 class="section-title">@Loc.T("sitemap.title", "Sitemap")</h2>
 

--- a/Pages/Technology.razor
+++ b/Pages/Technology.razor
@@ -3,6 +3,7 @@
 
 <PageTitle>@Loc.T("techpg.pagetitle", "Nano-Bubble Aeration Technology | Oxyniti")</PageTitle>
 <HeadContent>
+    <link rel="canonical" href="https://www.oxyniti.com/technology" />
     <meta name="description" content="@Loc.T("techpg.meta", "How Oxyniti's nano-shear chamber generates sub-200nm bubbles that stay suspended in water and keep transferring oxygen for days instead of seconds.")" />
 </HeadContent>
 

--- a/Pages/Terms.razor
+++ b/Pages/Terms.razor
@@ -4,6 +4,9 @@
 @inject LocalizationService Loc
 
 <PageTitle>Terms &amp; Conditions - Oxyniti</PageTitle>
+<HeadContent>
+    <link rel="canonical" href="https://www.oxyniti.com/terms" />
+</HeadContent>
 
 <h2 class="section-title">@Loc.T("terms.title", "Terms & Conditions")</h2>
 

--- a/wwwroot/index.html
+++ b/wwwroot/index.html
@@ -11,11 +11,20 @@
     <meta property="og:site_name" content="Oxyniti" />
     <meta property="og:title" content="Oxyniti — Infinite Oxygen. Infinite Yield." />
     <meta property="og:description" content="Nano-bubble generators that supercharge dissolved oxygen in fish ponds — healthier fish, faster growth, higher yield." />
-    <meta property="og:image" content="/oxyniti.png" />
-    <meta name="twitter:card" content="summary" />
+    <meta property="og:url" content="https://www.oxyniti.com/" />
+    <!-- unit-pondside is a real installed-unit photo, used here as an interim
+         banner (1120x630, 16:9) until a purpose-cropped 1200x630 share asset
+         with the wordmark replaces it. Must stay absolute: WhatsApp and most
+         other scrapers don't resolve relative og:image paths. -->
+    <meta property="og:image" content="https://www.oxyniti.com/images/unit-pondside@2x.jpg" />
+    <meta property="og:image:width" content="1120" />
+    <meta property="og:image:height" content="630" />
+    <meta property="og:image:alt" content="An Oxyniti nano-bubble unit installed at a fish pond" />
+    <meta property="og:locale" content="en_IN" />
+    <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Oxyniti — Infinite Oxygen. Infinite Yield." />
     <meta name="twitter:description" content="Nano-bubble generators that supercharge dissolved oxygen in fish ponds — healthier fish, faster growth, higher yield." />
-    <meta name="twitter:image" content="/oxyniti.png" />
+    <meta name="twitter:image" content="https://www.oxyniti.com/images/unit-pondside@2x.jpg" />
     <base href="/" />
 
     <link rel="icon" type="image/png" href="/oxyniti.png?v=2" />
@@ -55,12 +64,20 @@
     {
         "@context": "https://schema.org",
         "@type": ["Organization", "LocalBusiness"],
+        "@id": "https://www.oxyniti.com/#org",
         "name": "Oxyniti",
         "url": "https://www.oxyniti.com/",
         "logo": "https://www.oxyniti.com/oxyniti.png",
         "description": "Oxyniti builds nano-bubble oxygen generators for aquaculture, raising dissolved oxygen in fish and shrimp ponds to improve survival rate, feed conversion, and stocking density.",
         "areaServed": "Tamil Nadu, South India",
-        "telephone": "+91 96597 27477"
+        "telephone": "+91 96597 27477",
+        "contactPoint": [{
+            "@type": "ContactPoint",
+            "telephone": "+91 96597 27477",
+            "contactType": "sales",
+            "areaServed": "IN",
+            "availableLanguage": ["en", "ta", "te", "kn", "ml", "hi", "bn"]
+        }]
     }
     </script>
 </head>
@@ -180,6 +197,7 @@
             document.body.appendChild(el);
         })();
     </script>
+    <script src="./js/i18nHelper.js" defer></script>
     <script src="./js/clickOutsideHelper.js" defer></script>
     <script src="./js/tankBubbles.js" defer></script>
     <script src="./js/scrollHelper.js" defer></script>

--- a/wwwroot/js/i18nHelper.js
+++ b/wwwroot/js/i18nHelper.js
@@ -1,0 +1,5 @@
+window.oxynitiI18n = {
+    setHtmlLang: function (code) {
+        if (code) document.documentElement.lang = code;
+    }
+};


### PR DESCRIPTION
## Summary
Ships SEO-01 through SEO-08 from the Oxyniti discoverability work order — all markup/config-only fixes, no design or copy changes.

- **SEO-01** — real `/#section` hrefs on scroll nav links (was bare `#`); fixed remaining relative hrefs (`products`, `account`, `login`)
- **SEO-03** — self-referencing absolute `rel="canonical"` on all 10 sitemap URLs (previously none)
- **SEO-04** — absolute `og:image`/`twitter:image` (real product photo instead of the relative bare logo), `og:url`, image dimensions, `twitter:card` → `summary_large_image`
- **SEO-05** — `FAQPage` JSON-LD on the homepage (verbatim from `FAQSection.razor`), `ProductGroup` JSON-LD on `/products`, richer `Organization` `contactPoint`
- **SEO-06** — footer "Company" column (About/Contact/Privacy/Terms) + Products link; WhatsApp community block is now a real `<a>`
- **SEO-07** — syncs `document.documentElement.lang` when the language switcher changes
- **SEO-08** — removed the duplicate static `#blazor-error-ui` in `MainLayout.razor`, keeping the JS-created one from `index.html`

SEO-09/10/11 (prerendering, real 404s, per-language URLs) are intentionally out of scope — the work order itself calls those out as needing an architecture/hosting decision, not a markup edit.

Known follow-up: the OG image uses a real installed-unit photo (1120×630) as an interim banner; the work order calls for a purpose-designed 1200×630 asset with the wordmark, which doesn't exist yet.

## Test plan
- [x] `dotnet build` succeeds with 0 errors
- [ ] `curl` each sitemap URL and confirm a self-referencing canonical
- [ ] Google Rich Results Test on `/` (FAQPage) and `/products` (ProductGroup)
- [ ] Paste a link into WhatsApp / run Facebook Sharing Debugger to confirm the share card image renders
- [ ] Switch language in the header and confirm `<html lang>` updates
- [ ] Confirm only one `#blazor-error-ui` element in the live DOM

🤖 Generated with [Claude Code](https://claude.com/claude-code)