### PR TITLE
Drop synthetic Use Cases stills (interim fix for #78)

### DIFF
--- a/Pages/Components/FieldFootageSection.razor
+++ b/Pages/Components/FieldFootageSection.razor
@@ -6,8 +6,14 @@
 <div class="field-footage-section" id="use-cases">
     <span class="kicker">@Loc.T("gal.kicker", "Use cases")</span>
     <h2 class="section-title">@Loc.T("gal.h2", "No studio. No CGI. Just working ponds.")</h2>
-    <p class="section-lead">@Loc.T("gal.p", "Real footage and photos from a working farm during a live trial.")</p>
+    <p class="section-lead">@Loc.T("gal.p", "Real footage from a working farm during a live trial.")</p>
 
+    <!-- The two "install photo" stills that used to sit beside this video were
+         the same generated unit pair composited onto two different backdrops
+         (see tracked imagery issue) -- pulled rather than shipped next to a
+         "no CGI" claim. Restore a photo column here once real trial photos
+         exist; until then this section leads with the one asset that is
+         genuinely real footage. -->
     <div class="footage-grid">
         <div class="footage-card video-card">
             <video @ref="_videoElement" muted loop playsinline poster="/images/plume-poster.jpg">
@@ -15,24 +21,6 @@
                 <source data-src="/videos/plume-portrait.mp4" type="video/mp4" />
             </video>
             <div class="caption">@Loc.T("ff.cap1", "The nano-plume — oxygen dissolving in real time")</div>
-        </div>
-        <div class="footage-photos">
-            <div class="footage-card photo-card">
-                <picture>
-                    <source type="image/avif" srcset="/images/unit-pondside.avif 1x, /images/unit-pondside@2x.avif 2x" />
-                    <source type="image/webp" srcset="/images/unit-pondside.webp 1x, /images/unit-pondside@2x.webp 2x" />
-                    <img src="/images/unit-pondside.jpg" srcset="/images/unit-pondside.jpg 1x, /images/unit-pondside@2x.jpg 2x" width="560" height="315" loading="lazy" decoding="async" alt="Two Oxyniti units installed beside a fish pond" />
-                </picture>
-                <div class="caption">@Loc.T("ff.cap2", "On-site install — pond edge, ready to run")</div>
-            </div>
-            <div class="footage-card photo-card">
-                <picture>
-                    <source type="image/avif" srcset="/images/unit-fishfarm.avif 1x, /images/unit-fishfarm@2x.avif 2x" />
-                    <source type="image/webp" srcset="/images/unit-fishfarm.webp 1x, /images/unit-fishfarm@2x.webp 2x" />
-                    <img src="/images/unit-fishfarm.jpg" srcset="/images/unit-fishfarm.jpg 1x, /images/unit-fishfarm@2x.jpg 2x" width="560" height="315" loading="lazy" decoding="async" alt="Oxyniti units running at a family fish farm" />
-                </picture>
-                <div class="caption">@Loc.T("ff.cap3", "Family Fish Farm — live trial in progress")</div>
-            </div>
         </div>
     </div>
 </div>

--- a/Pages/Components/FieldFootageSection.razor.css
+++ b/Pages/Components/FieldFootageSection.razor.css
@@ -26,17 +26,8 @@
 }
 
 .footage-grid {
-    display: grid;
-    grid-template-columns: minmax(280px, 380px) 1fr;
-    gap: 1.25rem;
-    max-width: 960px;
+    max-width: 420px;
     margin: 0 auto;
-}
-
-.footage-photos {
-    display: grid;
-    grid-template-rows: 1fr 1fr;
-    gap: 1.25rem;
 }
 
 .footage-card {
@@ -46,12 +37,8 @@
     box-shadow: 0 4px 10px rgba(0, 0, 0, 0.2);
 }
 
-/* video-card has no aspect-ratio of its own on desktop: it stretches
-   (grid's default align-items) to match the height of the stacked
-   .footage-photos column next to it, instead of a hard-coded 3:4 box that
-   fell out of proportion whenever the photo column grew wider than expected. */
-.footage-card.photo-card {
-    aspect-ratio: 16 / 9;
+.footage-card.video-card {
+    aspect-ratio: 3 / 4;
 }
 
 .footage-card video,
@@ -60,18 +47,6 @@
     height: 100%;
     object-fit: cover;
     display: block;
-}
-
-@media (max-width: 760px) {
-    .footage-grid {
-        grid-template-columns: 1fr;
-    }
-
-    .footage-card.video-card {
-        aspect-ratio: 3 / 4;
-        width: min(420px, 100%);
-        margin: 0 auto;
-    }
 }
 
 .caption {


### PR DESCRIPTION
## Summary
- Interim fix for #78: the two "install photo" stills in the homepage Use Cases section were the same AI-generated unit pair composited onto two different backdrops, sitting directly under a "No studio. No CGI." claim.
- Confirmed by direct visual inspection: identical logo distortion, identical smeared panel-label text, identical hose routing and rear-unit offset in both files.
- Section now leads with just the plume video (genuine footage); sub-line no longer claims "photos" alongside the video.
- Real replacement photography is tracked separately in #78 and the broader asset audit in #79 — this PR does not close either.

## Test plan
- [x] `dotnet build` succeeds with 0 errors
- [ ] Visually confirm the Use Cases section on `/` renders a single centered portrait video with no leftover empty grid space
- [ ] Confirm mobile width still looks correct now that the two-column/photo breakpoint CSS was removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)