### PR TITLE
Fix footer: all four columns on one row, tighter brand gap

### DIFF
--- a/Pages/Components/Footer.razor.css
+++ b/Pages/Components/Footer.razor.css
@@ -12,8 +12,8 @@
 
 .footer-content {
     display: grid;
-    grid-template-columns: minmax(240px, 1.1fr) minmax(440px, 1.3fr);
-    gap: 3rem;
+    grid-template-columns: minmax(240px, 340px) minmax(0, 1fr);
+    gap: 2.5rem;
     margin-bottom: 2.5rem;
 }
 
@@ -105,7 +105,7 @@
 
 .footer-links {
     display: grid;
-    grid-template-columns: repeat(2, minmax(100px, 0.8fr)) minmax(220px, 1.3fr);
+    grid-template-columns: repeat(3, minmax(100px, 0.85fr)) minmax(200px, 1.1fr);
     gap: 2rem;
 }
 


### PR DESCRIPTION
## Summary
- `.footer-links` was still sized as a 3-column grid from before the Company column (added in #77) existed, so the 4th `.footer-section` (Company) wrapped Community down onto its own row.
- Widened `.footer-links` to a 4-column grid (Explore / Farmers / Company / Community) so all four sit on one row at desktop width.
- Capped `.footer-content`'s brand column at 340px instead of a 1.1fr share of the row — the logo + ~320px-wide description don't need the ~600px that fr sizing was giving them at wide viewports, which is what created the large dead gap before "Explore".

## Test plan
- [x] `dotnet build` succeeds with 0 errors
- [ ] Confirm on a wide viewport that Explore/Farmers/Company/Community render on one row with no big gap after the logo column
- [ ] Confirm mobile (≤768px) footer still looks correct — untouched in this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)