### PR TITLE
Build a real /faqs page with FAQPage JSON-LD (closes #72)

### DIFF
--- a/Pages/Components/FAQSection.razor
+++ b/Pages/Components/FAQSection.razor
@@ -1,7 +1,10 @@
 @inject LocalizationService Loc
 
 <div class="faq-section" id="faq">
-    <h2 class="section-title">@Loc.T("faq.kicker", "Frequently asked questions")</h2>
+    @if (ShowHeading)
+    {
+        <h2 class="section-title">@Loc.T("faq.kicker", "Frequently asked questions")</h2>
+    }
 
     <div class="faq-list">
         @for (var i = 0; i < Faqs.Count; i++)
@@ -23,6 +26,8 @@
 </div>
 
 @code {
+    [Parameter] public bool ShowHeading { get; set; } = true;
+
     private int? OpenIndex = 0;
 
     protected override void OnInitialized()
@@ -47,7 +52,7 @@
         new("Can I see it working on my own pond before I commit?",
             "Yes. Our team installs a unit on your pond, measures dissolved oxygen before and after with a calibrated DO meter, and shows you the difference the same day — no obligation."),
         new("How do I estimate the profit impact for my pond?",
-            "Use the profit calculator further up this page, or the Profit Calc button in the top bar — enter your pond size and species to see an estimate of the extra yield and margin."),
+            "Use the profit calculator on the homepage, or the Profit Calc button in the top bar — enter your pond size and species to see an estimate of the extra yield and margin."),
         new("Where do you currently install?",
             "We're currently serving Tamil Nadu and South India."),
     };

--- a/Pages/Faqs.razor
+++ b/Pages/Faqs.razor
@@ -1,17 +1,98 @@
 @page "/faqs"
+@implements IDisposable
 @inject LocalizationService Loc
 
-<PageTitle>@Loc.T("faqspage.title", "FAQs - Oxyniti")</PageTitle>
-
+<PageTitle>@Loc.T("faqspage.title", "Frequently Asked Questions | Oxyniti")</PageTitle>
 <HeadContent>
-    <meta name="robots" content="noindex" />
+    <link rel="canonical" href="https://www.oxyniti.com/faqs" />
+    <meta name="description" content="@Loc.T("faqspage.meta", "Answers to the questions farmers ask most before buying Oxyniti nano-bubble aeration — how it works, what results to expect, and where we currently install.")" />
+    <!-- Mirrors FAQSection.razor's questions/answers verbatim -- keep the two
+         in sync; a search engine or answer-engine crawler cross-checks the
+         JSON-LD text against the visible text and penalizes a mismatch. -->
+    <script type="application/ld+json">
+    {
+        "@@context": "https://schema.org",
+        "@@type": "FAQPage",
+        "mainEntity": [
+            {
+                "@@type": "Question",
+                "name": "How does Oxyniti actually raise dissolved oxygen?",
+                "acceptedAnswer": {
+                    "@@type": "Answer",
+                    "text": "Oxyniti dissolves oxygen into the pond as a fine nano-bubble plume instead of just churning the surface like a paddle wheel. The bubbles are small enough to stay suspended and dissolve into the water column, so oxygen reaches the fish even overnight, when algae stop producing oxygen and DO crashes."
+                }
+            },
+            {
+                "@@type": "Question",
+                "name": "How is this different from a paddle wheel aerator?",
+                "acceptedAnswer": {
+                    "@@type": "Answer",
+                    "text": "Paddle wheels mix the surface, but a lot of that oxygen escapes back into the air as fast as it goes in. Oxyniti's nano-bubbles have far more surface area and stay in the water longer, so more of the oxygen you're paying to add actually ends up dissolved."
+                }
+            },
+            {
+                "@@type": "Question",
+                "name": "What results can I expect?",
+                "acceptedAnswer": {
+                    "@@type": "Answer",
+                    "text": "Typical ranges reported in published nano-bubble aquaculture studies and field trials: around 2× higher dissolved oxygen, +15% survival rate, and -15% feed conversion ratio, which opens up roughly +30% stocking density. Actual results vary with species, pond condition and management."
+                }
+            },
+            {
+                "@@type": "Question",
+                "name": "Which species and pond types does it work for?",
+                "acceptedAnswer": {
+                    "@@type": "Answer",
+                    "text": "Tilapia/GIFT, Murrel, Pangasius, freshwater prawn, carp polyculture, and biofloc/RAS systems — on almost any pond, with install completed in about a day."
+                }
+            },
+            {
+                "@@type": "Question",
+                "name": "Can I see it working on my own pond before I commit?",
+                "acceptedAnswer": {
+                    "@@type": "Answer",
+                    "text": "Yes. Our team installs a unit on your pond, measures dissolved oxygen before and after with a calibrated DO meter, and shows you the difference the same day — no obligation."
+                }
+            },
+            {
+                "@@type": "Question",
+                "name": "How do I estimate the profit impact for my pond?",
+                "acceptedAnswer": {
+                    "@@type": "Answer",
+                    "text": "Use the profit calculator on the homepage, or the Profit Calc button in the top bar — enter your pond size and species to see an estimate of the extra yield and margin."
+                }
+            },
+            {
+                "@@type": "Question",
+                "name": "Where do you currently install?",
+                "acceptedAnswer": {
+                    "@@type": "Answer",
+                    "text": "We're currently serving Tamil Nadu and South India."
+                }
+            }
+        ]
+    }
+    </script>
 </HeadContent>
 
-<ComingSoon />
+<div class="faqs-page">
+    <span class="kicker">@Loc.T("faqspage.kicker", "Answers")</span>
+    <h1 class="section-title">@Loc.T("faqspage.h1", "Frequently Asked Questions")</h1>
+    <p class="section-lead">
+        @Loc.T("faqspage.lead", "Everything farmers ask before installing Oxyniti — how the nano-bubble plume works, what results to expect, and where we currently install.")
+    </p>
+
+    <FAQSection ShowHeading="false" />
+</div>
 
 @code {
     protected override void OnInitialized()
     {
         Loc.OnChange += StateHasChanged;
+    }
+
+    public void Dispose()
+    {
+        Loc.OnChange -= StateHasChanged;
     }
 }

--- a/Pages/Faqs.razor.css
+++ b/Pages/Faqs.razor.css
@@ -1,0 +1,33 @@
+.faqs-page {
+    max-width: 760px;
+    margin: 0 auto;
+    padding: 3rem 1.5rem;
+}
+
+.kicker {
+    display: inline-flex;
+    align-items: center;
+    gap: 10px;
+    font-size: 0.8rem;
+    font-weight: 700;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: #3D8FB5;
+    margin-bottom: 0.75rem;
+}
+
+.section-title {
+    color: #1A2C54;
+    font-size: 2.25rem;
+    font-weight: 600;
+    line-height: 1.25;
+    margin-bottom: 1rem;
+    padding: 0;
+}
+
+.section-lead {
+    color: #3a3a3a;
+    font-size: 1.05rem;
+    line-height: 1.6;
+    margin-bottom: 1rem;
+}

--- a/Pages/Home.razor
+++ b/Pages/Home.razor
@@ -57,7 +57,7 @@
                 "name": "How do I estimate the profit impact for my pond?",
                 "acceptedAnswer": {
                     "@@type": "Answer",
-                    "text": "Use the profit calculator further up this page, or the Profit Calc button in the top bar — enter your pond size and species to see an estimate of the extra yield and margin."
+                    "text": "Use the profit calculator on the homepage, or the Profit Calc button in the top bar — enter your pond size and species to see an estimate of the extra yield and margin."
                 }
             },
             {

--- a/wwwroot/sitemap.xml
+++ b/wwwroot/sitemap.xml
@@ -40,4 +40,8 @@
     <loc>https://www.oxyniti.com/sitemap</loc>
     <lastmod>2026-08-13</lastmod>
   </url>
+  <url>
+    <loc>https://www.oxyniti.com/faqs</loc>
+    <lastmod>2026-09-01</lastmod>
+  </url>
 </urlset>


### PR DESCRIPTION
## Summary
Closes #72. That issue had two parts:

1. **Already fixed** (583fc50, per the issue's own progress comment): `FAQSection.razor` renders all 7 `.faq-answer` divs unconditionally now — visibility is CSS-only (`.faq-item.open .faq-answer { display: block }`), so all seven answers are present in the raw HTML even for crawlers that don't execute JS.
2. **This PR**: `/faqs` still served `<ComingSoon/>` with a `noindex` meta tag (added under #66 while it was a stub). It's now a real page:
   - Renders the full `FAQSection` component under its own H1/lead copy
   - Added `FAQPage` JSON-LD (verbatim match to the visible text — the missing piece from #64)
   - Removed `noindex`, added a self-referencing canonical
   - Re-added `/faqs` to `sitemap.xml`

Also added a `ShowHeading` parameter to `FAQSection` so this standalone page can supply its own H1 instead of a duplicate "Frequently asked questions" heading directly under it.

**Bonus correctness fix**: FAQ answer #6 said "the profit calculator further up this page" — true when `FAQSection` sits on the homepage below the calculator, false on the new standalone `/faqs` page which has no calculator. Changed to "on the homepage" everywhere the text is duplicated (`FAQSection.razor`, `Home.razor`'s `FAQPage` JSON-LD, `Faqs.razor`'s `FAQPage` JSON-LD) — also matches wording `index.html`'s static shell already used, closing a small inconsistency between the two.

## Test plan
- [x] `dotnet build` succeeds with 0 errors
- [ ] `curl -s https://www.oxyniti.com/faqs` (no JS) shows all 7 questions and answers in the raw HTML
- [ ] Google Rich Results Test on `/faqs` — `FAQPage` parses with 0 errors
- [ ] Visual check: `/faqs` shows one H1 ("Frequently Asked Questions"), not a duplicate heading
- [ ] Confirm `/faqs` no longer has a `noindex` meta tag and has a self-referencing canonical

🤖 Generated with [Claude Code](https://claude.com/claude-code)