### PR TITLE
Add Product, BreadcrumbList and VideoObject JSON-LD (partial #64)

### DIFF
--- a/Pages/Home.razor
+++ b/Pages/Home.razor
@@ -71,6 +71,45 @@
         ]
     }
     </script>
+
+    <!-- uploadDate for each video is the date that file was first committed
+         to the site (verified via `git log --diff-filter=A`), used as the
+         real "published to oxyniti.com" date since no separate recording
+         date is tracked -- not an invented placeholder. -->
+    <script type="application/ld+json">
+    {
+        "@@context": "https://schema.org",
+        "@@type": "VideoObject",
+        "name": "Oxyniti nano-bubble generator running in a fish pond",
+        "description": "Oxyniti's nano-bubble generator floods a fish pond with trillions of invisible oxygen bubbles that stay dissolved for days -- not seconds.",
+        "thumbnailUrl": ["https://www.oxyniti.com/images/hero-poster-wide.jpg"],
+        "uploadDate": "2026-08-25",
+        "contentUrl": "https://www.oxyniti.com/videos/hero.mp4"
+    }
+    </script>
+    <script type="application/ld+json">
+    {
+        "@@context": "https://schema.org",
+        "@@type": "VideoObject",
+        "name": "Watch a pond come alive — from the sky",
+        "description": "Real footage from a live Oxyniti trial. Two units, one working pond — the milky plumes you see are pure oxygen going into solution.",
+        "thumbnailUrl": ["https://www.oxyniti.com/images/drone-poster.jpg"],
+        "uploadDate": "2026-08-25",
+        "contentUrl": "https://www.oxyniti.com/videos/drone.mp4"
+    }
+    </script>
+    <script type="application/ld+json">
+    {
+        "@@context": "https://schema.org",
+        "@@type": "VideoObject",
+        "name": "See the OXY-Nano Series in action",
+        "description": "Explore Oxyniti's nano-bubble technology and the OXY-Nano 1.5, 3 and 5 HP solutions in this complete product overview.",
+        "thumbnailUrl": ["https://www.oxyniti.com/images/oxy-nano-poster.webp"],
+        "uploadDate": "2026-08-17",
+        "duration": "PT6M53S",
+        "contentUrl": "https://www.oxyniti.com/videos/oxy-nano-series.mp4"
+    }
+    </script>
 </HeadContent>
 
 <div style="padding:10px;">

--- a/Pages/ProductDetails.razor
+++ b/Pages/ProductDetails.razor
@@ -1,4 +1,5 @@
 ﻿@page "/product/{Slug}"
+@using System.Text.Json.Serialization
 @inject IJSRuntime JSRuntime
 @inject NavigationManager Nav
 @inject CartService CartService
@@ -7,6 +8,16 @@
 @inject LocalizationService Loc
 
 <PageTitle>@(Detail?.Name ?? "Loading...")</PageTitle>
+
+@if (Detail is not null)
+{
+    <HeadContent>
+        <link rel="canonical" href="@CanonicalUrl" />
+        <meta name="description" content="@MetaDescription" />
+        <script type="application/ld+json">@((MarkupString)BuildProductJsonLd())</script>
+        <script type="application/ld+json">@((MarkupString)BuildBreadcrumbJsonLd())</script>
+    </HeadContent>
+}
 
 @if (Detail is null)
 {
@@ -314,6 +325,95 @@ else
     private string? AddedMessage;
     public IReadOnlyList<Maker.RampEdge.DigitalAsset> SortedAssets => Detail?.Assets.OrderBy(a => a.Is3DFile).ToList() ?? [];
     private IList<ProductData> AlsoLike { get; set; } = [];
+
+    private static readonly JsonSerializerOptions JsonLdOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+    };
+
+    private string CanonicalUrl => $"https://www.oxyniti.com/product/{Slug}";
+
+    private string MetaDescription =>
+        Detail is null
+            ? ""
+            : Detail.Description.Length > 155 ? Detail.Description[..155].TrimEnd() + "…" : Detail.Description;
+
+    // Built from the live ProductDetailsAsync response, not static markup --
+    // System.Text.Json escapes both JSON-special and HTML-unsafe characters
+    // (default JavaScriptEncoder), so a product name/description containing
+    // a quote or a literal "</script>" can't break out of the tag the way a
+    // raw @Detail.Name interpolation into the script body could.
+    private string BuildProductJsonLd()
+    {
+        var product = new JsonLdProduct
+        {
+            Name = Detail!.Name,
+            Description = Detail.Description,
+            Image = SortedAssets.FirstOrDefault(a => !a.Is3DFile)?.Url,
+            Offers = new JsonLdOffer
+            {
+                Url = CanonicalUrl,
+                Price = Detail.Price.ToString(System.Globalization.CultureInfo.InvariantCulture)
+            }
+        };
+
+        return JsonSerializer.Serialize(product, JsonLdOptions);
+    }
+
+    private string BuildBreadcrumbJsonLd()
+    {
+        var breadcrumb = new JsonLdBreadcrumbList
+        {
+            ItemListElement =
+            [
+                new JsonLdListItem { Position = 1, Name = "Home", Item = "https://www.oxyniti.com/" },
+                new JsonLdListItem { Position = 2, Name = "Products", Item = "https://www.oxyniti.com/products" },
+                new JsonLdListItem { Position = 3, Name = Detail!.Name, Item = CanonicalUrl }
+            ]
+        };
+
+        return JsonSerializer.Serialize(breadcrumb, JsonLdOptions);
+    }
+
+    private sealed class JsonLdProduct
+    {
+        [JsonPropertyName("@context")] public string Context => "https://schema.org";
+        [JsonPropertyName("@type")] public string Type => "Product";
+        public string Name { get; set; } = "";
+        public string? Description { get; set; }
+        public string? Image { get; set; }
+        public JsonLdBrand Brand { get; set; } = new();
+        public JsonLdOffer Offers { get; set; } = new();
+    }
+
+    private sealed class JsonLdBrand
+    {
+        [JsonPropertyName("@type")] public string Type => "Brand";
+        public string Name => "Oxyniti";
+    }
+
+    private sealed class JsonLdOffer
+    {
+        [JsonPropertyName("@type")] public string Type => "Offer";
+        public string Url { get; set; } = "";
+        public string PriceCurrency => "INR";
+        public string Price { get; set; } = "";
+    }
+
+    private sealed class JsonLdBreadcrumbList
+    {
+        [JsonPropertyName("@context")] public string Context => "https://schema.org";
+        [JsonPropertyName("@type")] public string Type => "BreadcrumbList";
+        public List<JsonLdListItem> ItemListElement { get; set; } = [];
+    }
+
+    private sealed class JsonLdListItem
+    {
+        [JsonPropertyName("@type")] public string Type => "ListItem";
+        public int Position { get; set; }
+        public string Name { get; set; } = "";
+        public string Item { get; set; } = "";
+    }
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {


### PR DESCRIPTION
## Summary
Continues #64. Of the five schema types listed in that issue's Fix section:

| Type | Status |
|---|---|
| `Organization` + `LocalBusiness` | ✅ done previously (static, `index.html`) |
| `FAQPage` | ✅ done previously (Home + `/faqs`) |
| `Product` (offers + brand) | ✅ **this PR** — `/product/{Slug}` |
| `BreadcrumbList` on nested routes | ✅ **this PR** — `/product/{Slug}` |
| `VideoObject` (hero + OXY-NANO + sky-view) | ✅ **this PR** — homepage |

**Product + BreadcrumbList** (`ProductDetails.razor`): built via `System.Text.Json.JsonSerializer` from the live `ProductDetailsAsync` response, not raw string interpolation — that data comes from an external API, and the default `JavaScriptEncoder` escapes both JSON-special and HTML-unsafe characters, so a product name/description containing a quote or a literal `</script>` can't break the tag. Also adds a canonical link and meta description, which this page previously had neither of.

**VideoObject** (`Home.razor`): one block each for the hero video, the drone/sky-view video, and the OXY-Nano Series video (see #19, #21). `uploadDate` on each is the date that file was first committed to the repo (`git log --diff-filter=A`) — a real, verifiable "published to the site" date, not an invented one, since no separate recording date is tracked anywhere.

## Why this doesn't close #64

#64's own Fix section says the fuller JSON-LD set "depends on the marketing routes being prerendered" (#63). Everything above — like the `FAQPage`/`Organization` work already merged — is emitted through Blazor's `HeadContent`/`HeadOutlet`, so it renders correctly for anything that executes JS (should pass the Rich Results Test), but it is **not present in the no-JS response**, which is #64's second acceptance criterion. Every route still serves the identical static `index.html` until Blazor boots (per #63, still open), so per-route JSON-LD structurally can't reach that raw response without prerendering shipping first — the same limitation the previous partial-progress commit (583fc50) already flagged for `FAQPage`/`Product`. I'm not attempting a prerender pipeline as a side effect of this ticket; that's #63's own scope.

Leaving #64 open, with a status comment there.

## Test plan
- [x] `dotnet build` succeeds with 0 errors
- [ ] Rich Results Test on a live `/product/{slug}` URL — `Product` and `BreadcrumbList` parse with 0 errors
- [ ] Rich Results Test on `/` — all three `VideoObject` blocks parse with 0 errors
- [ ] Manually confirm a product name/description containing a quote renders valid JSON (no live product with one on hand to test against)

🤖 Generated with [Claude Code](https://claude.com/claude-code)