### PR TITLE
fix(trust): remove fake-provenance imagery and audit all shipped assets

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,26 @@
+# Contributing
+
+## Imagery & provenance
+
+**No generated or composited imagery in any section that makes a
+provenance, trial, or customer-installation claim.** If copy near an image
+or video says (or implies) "real", "live trial", "installed", "footage", or
+similar, the asset must be genuine camera-captured photo/video — not an
+AI-generated, AI-composited, or otherwise synthetic image.
+
+Renders, illustrations, and product visualizations are welcome, but must be
+placed in a section that makes no such claim, and captioned clearly as a
+render/visualization so a viewer cannot mistake it for evidence.
+
+Before adding a new image or video to `wwwroot/images/` or `wwwroot/videos/`
+and referencing it from a claim-making section (Use Cases, Results, any
+"real footage" / "live trial" copy), add a row for it to
+[`docs/image-provenance.md`](docs/image-provenance.md) recording its source,
+where it is used, and what claim (if any) the surrounding copy makes.
+
+This rule exists because of
+[#78](https://github.com/revred/Oxiniti/issues/78): two AI-generated,
+composited product-unit renders were shipped captioned as trial photography
+in the homepage Use Cases section, directly under a "No studio. No CGI."
+headline — see [#79](https://github.com/revred/Oxiniti/issues/79) for the
+follow-up audit.

--- a/docs/image-provenance.md
+++ b/docs/image-provenance.md
@@ -1,0 +1,85 @@
+# Image & video provenance inventory
+
+Audit requested by [#79](https://github.com/revred/Oxiniti/issues/79), following
+the synthetic-images-as-trial-photography finding in
+[#78](https://github.com/revred/Oxiniti/issues/78).
+
+Every image/video shipped under `wwwroot/images/` and `wwwroot/videos/` is
+listed below with: where it is used, what the surrounding copy claims about
+it (if anything), and its source as best determined by direct inspection
+(camera footage vs. rendered graphic vs. AI-generated/composited) plus repo
+history where available. "Claim" means the surrounding copy asserts the
+asset is real footage, a real installation, or trial evidence, as opposed to
+a labelled render or a plain decorative/UI image that makes no such claim.
+
+## Homepage marketing assets
+
+| Asset | Used in | Claim made by surrounding copy | Source | Status |
+|---|---|---|---|---|
+| `hero-poster-wide.avif` / `.jpg` | `Hero.razor` (video poster), `wwwroot/index.html` (shell + og:image), `Home.razor` JSON-LD `thumbnailUrl` | "Infinite Oxygen. Infinite Yield." — implicit real-product claim via hero video | Real photo/video frame — visibly a genuine pond scene (net enclosure, staked poles, natural imperfections), consistent with `hero.mp4` | OK |
+| `hero-poster.avif` / `.jpg` (non-`-wide`) | Not referenced anywhere in current code | none | Unknown (unused) | **Orphaned** — safe to delete or confirm intentionally kept for a future crop |
+| `drone-poster.jpg` | `SkyViewSection.razor` (video poster), `Home.razor` JSON-LD `thumbnailUrl` | "Real footage from a live Oxyniti trial." / `DRONE · LIVE TRIAL` badge | Real aerial/drone footage frame — two people, a boat, tanks and hoses in a natural pond setting, consistent with `drone.mp4` | OK |
+| `plume-poster.jpg` | `FieldFootageSection.razor` (video poster) | "The nano-plume — oxygen dissolving in real time" | Real footage frame — same net-enclosure scene as the hero shot, visible turbulence from the diffuser | OK |
+| `oxy-nano-poster.webp` | `OxyNanoVideoSection.razor` (video poster), `Home.razor` JSON-LD | "See the OXY-Nano Series in action" — product overview, not a trial/authenticity claim | Produced graphic/slide (spec comparison card), not a photograph | OK — it is an explainer graphic and is not presented as photography |
+| `unit-pondside@2x.{avif,jpg,webp}` / `unit-pondside.{avif,jpg,webp}` | Formerly `FieldFootageSection.razor` and `wwwroot/index.html` og:image/twitter:image | Was captioned "On-site install — pond edge, ready to run" / alt "installed at a fish pond" | **AI-generated/composited** — confirmed by direct visual inspection: identical unit cluster, hose routing, hardware placement and distorted logo/panel-label artifacts as `unit-fishfarm@2x`, on a different backdrop | **Fixed** — removed from `FieldFootageSection.razor` (#78 interim fix) and from `index.html` og:image (this PR). No longer referenced anywhere. File retained on disk, unused. |
+| `unit-fishfarm@2x.{avif,jpg,webp}` / `unit-fishfarm.{avif,jpg,webp}` | Formerly `FieldFootageSection.razor` | Was captioned "Family Fish Farm — live trial in progress" | **AI-generated/composited** — same unit pair as `unit-pondside@2x`, see above | **Fixed** — removed from `FieldFootageSection.razor` (#78 interim fix). No longer referenced anywhere. File retained on disk, unused. |
+
+## Video files
+
+| Asset | Used in | Claim made by surrounding copy | Source | Status |
+|---|---|---|---|---|
+| `hero.webm` / `hero.mp4` | `Hero.razor` | Implicit real-product claim (hero background loop) | Real footage (matches `hero-poster-wide.jpg`) | OK |
+| `drone.webm` / `drone.mp4` | `SkyViewSection.razor` | "Real footage from a live Oxyniti trial" | Real aerial footage (matches `drone-poster.jpg`) | OK |
+| `plume-portrait.webm` / `plume-portrait.mp4` | `FieldFootageSection.razor` | "The nano-plume — oxygen dissolving in real time" | Real footage (matches `plume-poster.jpg`); explicitly called out in #78 as reading genuine | OK |
+| `oxy-nano-series.mp4` | `OxyNanoVideoSection.razor`, `Home.razor` JSON-LD | Product overview / spec walkthrough, no authenticity claim | Produced explainer video (graphics + VO), not documentary footage | OK — not presented as trial evidence |
+| `oxyniti_explainer_16x9_tamil.mp4` | `OxyNanoVideoSection.razor` (Tamil locale variant) | Same as above | Produced explainer video, Tamil dub/localisation of the same asset | OK |
+| `drone_enhanced.mp4` | Not referenced anywhere in current code | none | Unknown (unused) | **Orphaned** — likely a superseded edit of `drone.mp4`; confirm and delete if so |
+
+## Decorative / UI assets (no provenance claim)
+
+These are icons, illustrations, or generic textures used as UI chrome, not as
+evidence of a real installation or trial — no provenance claim is made about
+them and none require captioning:
+
+- `efficiency.png/.webp`, `maintenance.png/.webp`, `precision.png/.webp`, `performance.png/.webp` — line-art icons next to feature copy on `About.razor` / `TechnologySection.razor` / `ExploreProductRange.razor`.
+- `login.jpg/.avif/.webp`, `login-right.jpg` — generic underwater-texture background on auth pages (`Login.razor`, `Register.razor`, etc.).
+- `placeholder.png` — Bootstrap-style loading placeholder used across product/search/account pages.
+- `avatar.png` — fallback author avatar styling target for CMS-driven `Testimonials.razor` content; the actual testimonial photos/names come from the CMS (`InfoService.Testimonials`) and are out of this repo's scope — audit them where the CMS content is authored.
+- `arun.png` — a named individual's headshot; not currently referenced in any `.razor` file in this repo (check CMS/About content if it is meant to be in use).
+- `retrofit-kits.jpg` — not currently referenced in any `.razor` file in this repo.
+- `oxyniti.png` — favicon/wordmark.
+
+## Product imagery (out of this repo's scope)
+
+`FeaturedProducts.razor`, `DiscoverProductTypes.razor` and the `/products/*`
+pages render product images from `p.Asset?.Url`, fetched at runtime from the
+Maker backend/CMS rather than shipped in `wwwroot/`. This audit only covers
+static assets checked into this repository; product-catalogue imagery should
+be audited where it is uploaded (the CMS/admin tooling), against the same
+rule below.
+
+## Findings
+
+No further synthetic-as-real assets were found among the currently
+displayed images/videos. `unit-pondside*` and `unit-fishfarm*` (both flagged
+in #78) are the only assets that were AI-generated/composited and shown
+under an authenticity claim; both have been removed from every page that
+displays them (this PR completes the fix that #78's interim change started).
+Two video files (`hero-poster.*`, `drone_enhanced.mp4`) and two image files
+appear orphaned (unreferenced) and are noted above for cleanup, not because
+they pose a trust risk.
+
+## Shot list for the next site visit
+
+So replacement/expansion photography for the Use Cases section can be
+captured in one trip:
+
+1. **Wide pond context** — the pond/farm from a distance, showing scale and setting (the kind of shot that currently only exists as drone footage).
+2. **Unit at pond edge, with a person for scale** — matching the framing the removed renders faked, but real: imperfect angle, visible cabling, a person operating or standing near the unit.
+3. **Panel close-up with legible labels** — pressure gauge, water outlet, gas inlet legible and in focus (the generated stills smeared this text — a real close-up directly rebuts that).
+4. **DO meter reading in frame** — the free DO-meter demo is called out in #79 as "the strongest credibility asset on the site"; a photo of an actual meter reading during a demo is high-value.
+5. **Install in progress** — hoses being connected, unit being positioned — process shots read as more authentic than a finished, static product shot.
+
+Once captured, these should replace the placeholder-free `FieldFootageSection.razor`
+per the original acceptance criteria in #78 (real photos preferred over any
+relocated render).

--- a/wwwroot/index.html
+++ b/wwwroot/index.html
@@ -12,19 +12,22 @@
     <meta property="og:title" content="Oxyniti — Infinite Oxygen. Infinite Yield." />
     <meta property="og:description" content="Nano-bubble generators that supercharge dissolved oxygen in fish ponds — healthier fish, faster growth, higher yield." />
     <meta property="og:url" content="https://www.oxyniti.com/" />
-    <!-- unit-pondside is a real installed-unit photo, used here as an interim
-         banner (1120x630, 16:9) until a purpose-cropped 1200x630 share asset
-         with the wordmark replaces it. Must stay absolute: WhatsApp and most
-         other scrapers don't resolve relative og:image paths. -->
-    <meta property="og:image" content="https://www.oxyniti.com/images/unit-pondside@2x.jpg" />
-    <meta property="og:image:width" content="1120" />
-    <meta property="og:image:height" content="630" />
-    <meta property="og:image:alt" content="An Oxyniti nano-bubble unit installed at a fish pond" />
+    <!-- unit-pondside@2x.jpg was found to be a generated/composited render, not
+         a real installed-unit photo (see Oxiniti#78) -- do not use it, or its
+         unit-fishfarm@2x.jpg twin, anywhere that implies real installed
+         hardware. hero-poster-wide.jpg is genuine hero-video footage (already
+         the VideoObject thumbnail in Home.razor's JSON-LD), used here as the
+         share banner instead. Must stay absolute: WhatsApp and most other
+         scrapers don't resolve relative og:image paths. -->
+    <meta property="og:image" content="https://www.oxyniti.com/images/hero-poster-wide.jpg" />
+    <meta property="og:image:width" content="1280" />
+    <meta property="og:image:height" content="720" />
+    <meta property="og:image:alt" content="An Oxyniti nano-bubble generator dissolving oxygen into a fish pond" />
     <meta property="og:locale" content="en_IN" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Oxyniti — Infinite Oxygen. Infinite Yield." />
     <meta name="twitter:description" content="Nano-bubble generators that supercharge dissolved oxygen in fish ponds — healthier fish, faster growth, higher yield." />
-    <meta name="twitter:image" content="https://www.oxyniti.com/images/unit-pondside@2x.jpg" />
+    <meta name="twitter:image" content="https://www.oxyniti.com/images/hero-poster-wide.jpg" />
     <base href="/" />
 
     <link rel="icon" type="image/png" href="/oxyniti.png?v=2" />


### PR DESCRIPTION
## Summary

### #78 — synthetic unit-pair composite captioned as trial photography
- `FieldFootageSection.razor` had already dropped the two duplicate `unit-pondside`/`unit-fishfarm` stills from the homepage Use Cases section (interim fix noted in #78).
- Remaining gap: `wwwroot/index.html` still used `unit-pondside@2x.jpg` as the site's `og:image`/`twitter:image`, with alt text claiming an "installed" unit — repeating the same false authenticity claim on every social share of the site. A stale comment there even asserted it was "a real installed-unit photo," which direct visual inspection disproves (identical unit cluster/hose routing/distorted logo composited onto two backdrops, exactly as described in #78).
- Swapped the share-card image to `hero-poster-wide.jpg` — genuine hero-video footage already used as the `VideoObject` thumbnail in `Home.razor`'s JSON-LD — and corrected alt text + dimensions to match.
- Verified no other reference to `unit-pondside`/`unit-fishfarm` remains anywhere in the codebase.

### #79 — audit every shipped image/video, add a no-fake-provenance rule
- Reviewed every asset under `wwwroot/images/` and `wwwroot/videos/`: where it's used, what claim (if any) the surrounding copy makes, and its source (real footage vs. produced graphic vs. AI-generated), verified by direct visual inspection and cross-referencing each poster frame against its matching video.
- Findings written up in [`docs/image-provenance.md`](docs/image-provenance.md). Only `unit-pondside*`/`unit-fishfarm*` (addressed above) were synthetic-as-real; every other claim-bearing photo/video (hero, drone, plume) is genuine, and graphics like the OXY-Nano explainer poster make no authenticity claim. A couple of orphaned/unreferenced files are flagged for cleanup, not a trust issue.
- Added `CONTRIBUTING.md` with the requested rule: no generated/composited imagery in any section making a provenance/trial/installation claim; renders are fine elsewhere as long as they're labelled and captioned.
- Added a shot list for the next site visit so replacement Use Cases photography (wide pond context, unit at pond edge with a person for scale, panel close-up, DO-meter reading, install in progress) can be captured in one trip.

Closes #78
Closes #79

## Acceptance criteria (#78)
- [x] No image in a section making an authenticity claim is synthetic or composited.
- [x] Any retained render is captioned as a render, in a section that makes no provenance claim. (Neither flagged image is displayed anywhere now.)
- [x] `alt` text matches what the image actually is.

## Deliverables (#79)
- [x] Asset inventory (`docs/image-provenance.md`) covering every shipped image and video.
- [x] Further synthetic assets in claim-making contexts flagged — none found beyond #78's.
- [x] Contributing rule against fake-provenance imagery (`CONTRIBUTING.md`).
- [x] Shot list for the next site visit.

## Test plan
- [x] Diffed `wwwroot/index.html` to confirm only the og/twitter image meta tags changed.
- [x] Grepped the repo for `unit-pondside`/`unit-fishfarm` to confirm no remaining display references.
- [x] Visually inspected every claim-bearing image/poster against its matching video to confirm genuine footage vs. produced graphic vs. synthetic.
- [ ] Manually reload a social-share preview (e.g. Facebook Sharing Debugger / Twitter Card Validator) against the deployed URL to confirm the new share image renders correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)