### PR TITLE
fix(branding): don't trust a signed, time-limited CMS logo URL

### DIFF
--- a/Services/BusinessInfoService.cs
+++ b/Services/BusinessInfoService.cs
@@ -27,7 +27,19 @@ namespace Oxyniti.Services
 
         /// <summary>CMS logo once it lands, the shipped brand asset until then — never empty.</summary>
         public string LogoUrl =>
-            !string.IsNullOrWhiteSpace(Asset?.Url) ? Asset!.Url : DefaultLogoUrl;
+            !string.IsNullOrWhiteSpace(Asset?.Url) && !IsTimeLimitedUrl(Asset!.Url)
+                ? Asset!.Url
+                : DefaultLogoUrl;
+
+        /// <summary>
+        /// A Supabase Storage signed URL (".../object/sign/...?token=...") expires
+        /// minutes after issuance — unusable for a public brand asset that has to
+        /// survive prerendering and caching. Treat one as if the CMS supplied
+        /// nothing rather than ship a logo URL that goes dead in the wild.
+        /// See https://github.com/revred/Oxiniti/issues/80.
+        /// </summary>
+        private static bool IsTimeLimitedUrl(string url) =>
+            url.Contains("/object/sign/", StringComparison.OrdinalIgnoreCase);
 
         /// <summary>True once the fetch has settled, whether it succeeded or failed.</summary>
         public bool IsLoaded { get; private set; }


### PR DESCRIPTION
## Summary

- `BusinessInfoService.LogoUrl` (`Services/BusinessInfoService.cs`) used whatever `Asset.Url` the CMS's `GetBusinessInfoAsync()` call returned, unconditionally.
- The Maker/RampEdge CMS backend currently supplies a **Supabase Storage signed URL** for the logo (`.../object/sign/...?token=<JWT>`) with a **300-second expiry**, so the footer/header logo (`NavMenu.razor`, `Footer.razor` — both just bind `InfoService.LogoUrl`) goes dead (`naturalWidth === 0`) a few minutes after load, and is already dead on arrival for any prerendered/cached copy of the page (compounding #75/#63's prerendering work).
- The durable fix belongs upstream — the CMS should stop signing a public brand asset at all, per the issue's preferred fix — but that service isn't in this repo.
- Within this repo's control, `LogoUrl` now refuses to treat a signed/time-limited URL as authoritative: it falls back to the shipped same-origin default (`/oxyniti.png`, no expiry) whenever the CMS-supplied URL contains `/object/sign/`, exactly like the existing fallback when the CMS supplies nothing at all.

Closes #80

## Acceptance criteria
- [x] Footer logo renders on a cold load and on a prerendered/cached page — it now always resolves to a same-origin, non-expiring URL unless/until the CMS stops signing it.
- [x] No public brand asset is served from a time-limited signed URL — from this repo's side, the signed URL is never surfaced as `LogoUrl` in the first place.

## Out of scope
- The upstream CMS/Supabase-side fix (making the logo asset actually public/unsigned) — not in this repo.
- The Testimonials HTML block signed-URL follow-up mentioned in the issue — tracked separately in #81.

## Test plan
- [x] `dotnet build Oxyniti.csproj` — succeeds, 0 warnings/errors.
- [x] Traced both consumers (`Layout/NavMenu.razor:11`, `Pages/Components/Footer.razor:9`) to confirm both bind `InfoService.LogoUrl`/`Info.LogoUrl` and get the fix for free.
- [ ] Manually verify against a live CMS response containing a `/object/sign/` logo URL that the rendered `<img src>` is `/oxyniti.png`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)