### PR TITLE
fix(testimonials): strip CMS-supplied avatar <img> tags with no usable src

### DIFF
--- a/Pages/Components/Testimonials.razor
+++ b/Pages/Components/Testimonials.razor
@@ -1,4 +1,5 @@
-﻿@implements IDisposable
+﻿@using System.Text.RegularExpressions
+@implements IDisposable
 @inject BusinessInfoService InfoService
 @inject LocalizationService Loc
 @inject IJSRuntime JS
@@ -10,12 +11,34 @@
     <section class="testimonials-section" id="testimonials">
         <h2 class="section-title">@Loc.T("testi.h1", "Testimonials")</h2>
         <div>
-            @((MarkupString)InfoService.Testimonials)
+            @((MarkupString)SanitizedTestimonials)
         </div>
     </section>
 }
 
 @code {
+    // The CMS has shipped <img> avatar tags with an empty/missing src, which
+    // the browser resolves to the page's own URL -- a wasted full-document
+    // request per avatar (see https://github.com/revred/Oxiniti/issues/81).
+    // The real fix belongs in the CMS template; this is defense-in-depth so a
+    // future regression there degrades to no image (the .author-avatar circle
+    // still renders from CSS) instead of firing duplicate document requests.
+    private static readonly Regex ImgTagPattern =
+        new(@"<img\b[^>]*>", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+    private static readonly Regex SrcAttrPattern =
+        new(@"\bsrc\s*=\s*(['""])(.*?)\1", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+    private string SanitizedTestimonials =>
+        ImgTagPattern.Replace(InfoService.Testimonials, StripImgWithoutUsableSrc);
+
+    private static string StripImgWithoutUsableSrc(Match imgTag)
+    {
+        var srcAttr = SrcAttrPattern.Match(imgTag.Value);
+        var hasUsableSrc = srcAttr.Success && !string.IsNullOrWhiteSpace(srcAttr.Groups[2].Value);
+        return hasUsableSrc ? imgTag.Value : string.Empty;
+    }
+
     protected override void OnInitialized()
     {
         Loc.OnChange += StateHasChanged;


### PR DESCRIPTION
## Summary

- `Testimonials.razor` renders `InfoService.Testimonials` verbatim as `MarkupString` — raw HTML returned by the Maker/RampEdge CMS's `GetBusinessInfoAsync()`. There is no Blazor `src="@..."` binding involved.
- The CMS currently emits `<img>` avatar tags (Ramesh, Suresh, Jogesh, Kumar) with an empty/missing `src`, which the browser resolves against the page's own URL (`https://www.oxyniti.com/`) — each one silently fires a second request for the entire homepage document, discarded as an invalid image. 4 wasted full-page requests per pageview, compounding the boot-performance work in #75.
- The durable fix belongs in the CMS template that generates this markup (not in this repo) — but the issue explicitly asks for an Oxyniti-side defense-in-depth fix too, since the incoming content is untrusted CMS HTML.
- Added a small regex-based sanitizer that strips any `<img>` tag with an empty/whitespace or absent `src` before the HTML is rendered. The surrounding `.author-avatar` div keeps its bordered-circle CSS styling either way, so a broken/missing avatar now degrades to an empty circle with **zero** network requests, instead of a broken-image icon plus a duplicate document fetch. A verified test case (in-tool, not checked into the repo) confirmed real `<img src="/images/real.jpg">` tags pass through untouched while empty/missing-`src` tags are removed.

Closes #81

## Acceptance criteria
- [x] All four avatars render, or degrade to a fallback that issues no network request — they now degrade to the empty bordered circle, no request fired.
- [x] No `img` in the CMS-supplied testimonials HTML ships an empty or null `src` once rendered by this repo (the tag is removed rather than rendered with an empty `src`).
- [x] Network panel shows no duplicate document requests on the homepage — from this repo's side, since no `src=""` ever reaches the DOM.

## Out of scope
- The upstream CMS/template fix (so the avatar field is never empty/null in the first place) — not in this repo.
- The signed-URL logo fix — tracked and fixed separately in #80 (PR #89).

## Test plan
- [x] `dotnet build Oxyniti.csproj` — succeeds, 0 warnings/errors.
- [x] Verified the sanitizer regex against representative CMS HTML (empty `src=""`, missing `src`, and a real `src="/images/real.jpg"`) — only the two broken tags are stripped, the real avatar is untouched.
- [ ] Manually verify against a live CMS response in a browser Network panel that no duplicate `/` document requests fire.

🤖 Generated with [Claude Code](https://claude.com/claude-code)