### PR TITLE
feat(blog): scaffold the /blogs section

### DIFF
--- a/Pages/Blogs.razor
+++ b/Pages/Blogs.razor
@@ -1,15 +1,65 @@
-﻿@page "/blogs"
+@page "/blogs"
+@implements IDisposable
 @inject LocalizationService Loc
 
+<PageTitle>@Loc.T("blogs.pagetitle", "Blog | Oxyniti Nano-Bubble Aeration")</PageTitle>
 <HeadContent>
-    <meta name="robots" content="noindex" />
+    <link rel="canonical" href="https://www.oxyniti.com/blogs" />
+    <meta name="description" content="@Loc.T("blogs.meta", "Field notes, trial data and technical explainers on nano-bubble aeration for aquaculture, wastewater treatment and hydroponics, from the Oxyniti team.")" />
+    @* Nothing indexable exists here yet -- an empty section only hurts crawl
+       quality. Flip automatically the moment BlogRegistry.Posts gets its
+       first real entry; see BlogRegistry for how to add one. *@
+    <meta name="robots" content="@(BlogRegistry.Posts.Count == 0 ? "noindex" : "index, follow")" />
 </HeadContent>
 
-<ComingSoon/>
+@if (BlogRegistry.Posts.Count > 0)
+{
+    <script type="application/ld+json">
+    {
+        "@@context": "https://schema.org",
+        "@@type": "Blog",
+        "name": "Oxyniti Blog",
+        "url": "https://www.oxyniti.com/blogs"
+    }
+    </script>
+}
+
+<div class="blogs-section">
+    <span class="kicker">@Loc.T("blogs.kicker", "Field notes")</span>
+    <h2 class="section-title">@Loc.T("blogs.h2", "Blog")</h2>
+    <p class="section-lead">
+        @Loc.T("blogs.lead", "Trial data, technical explainers and field notes on nano-bubble aeration — published as they're ready, not before.")
+    </p>
+
+    @if (BlogRegistry.Posts.Count == 0)
+    {
+        <div class="blogs-empty">
+            <p>@Loc.T("blogs.empty", "The first post is on its way. Check back soon.")</p>
+        </div>
+    }
+    else
+    {
+        <div class="blogs-grid">
+            @foreach (var post in BlogRegistry.Posts.OrderByDescending(p => p.PublishedOn))
+            {
+                <a class="blog-card" href="@($"/blogs/{post.Slug}")">
+                    <span class="blog-date">@post.PublishedOn.ToString("MMMM d, yyyy")</span>
+                    <h3>@post.Title</h3>
+                    <p>@post.Summary</p>
+                </a>
+            }
+        </div>
+    }
+</div>
 
 @code {
     protected override void OnInitialized()
     {
         Loc.OnChange += StateHasChanged;
+    }
+
+    public void Dispose()
+    {
+        Loc.OnChange -= StateHasChanged;
     }
 }

--- a/Pages/Blogs.razor.css
+++ b/Pages/Blogs.razor.css
@@ -1,0 +1,84 @@
+.blogs-section {
+    padding: 3rem 1.5rem;
+    max-width: 1100px;
+    margin: 0 auto;
+}
+
+.kicker {
+    display: inline-block;
+    font-size: 0.8rem;
+    font-weight: 700;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: #3D8FB5;
+    margin-bottom: 0.75rem;
+}
+
+.section-title {
+    color: #1A2C54;
+    font-size: 2.25rem;
+    font-weight: 600;
+    margin-bottom: 1rem;
+}
+
+.section-lead {
+    color: #3a3a3a;
+    font-size: 1.02rem;
+    line-height: 1.6;
+    margin-bottom: 2rem;
+    max-width: 60ch;
+}
+
+.blogs-empty {
+    border: 1px dashed rgba(26, 44, 84, 0.25);
+    border-radius: 0.75rem;
+    padding: 2.5rem 1.5rem;
+    text-align: center;
+    color: #555;
+}
+
+.blogs-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: 1.5rem;
+}
+
+.blog-card {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    border-radius: 0.75rem;
+    padding: 1.75rem;
+    background: #fff;
+    box-shadow: 0 4px 10px rgba(0, 0, 0, 0.08);
+    color: inherit;
+    text-decoration: none;
+    transition: transform 0.2s, box-shadow 0.2s;
+}
+
+    .blog-card:hover {
+        transform: translateY(-3px);
+        box-shadow: 0 8px 20px rgba(0, 0, 0, 0.12);
+    }
+
+    .blog-card .blog-date {
+        font-size: 0.8rem;
+        font-weight: 600;
+        letter-spacing: 0.04em;
+        text-transform: uppercase;
+        color: #3D8FB5;
+    }
+
+    .blog-card h3 {
+        color: #1A2C54;
+        font-size: 1.15rem;
+        font-weight: 700;
+        margin: 0;
+    }
+
+    .blog-card p {
+        color: #555;
+        font-size: 0.92rem;
+        line-height: 1.5;
+        margin: 0;
+    }

--- a/Services/BlogRegistry.cs
+++ b/Services/BlogRegistry.cs
@@ -1,0 +1,31 @@
+namespace Oxyniti.Services;
+
+/// <summary>
+/// One entry in <see cref="BlogRegistry.Posts"/> — just enough to render the
+/// /blogs index card and link to the post's own page.
+/// </summary>
+public record BlogPostSummary(string Slug, string Title, string Summary, DateOnly PublishedOn);
+
+/// <summary>
+/// The list of published posts under /blogs (see
+/// https://github.com/revred/Oxiniti/issues/70). Starts empty: no placeholder
+/// or fabricated post belongs here — every entry must correspond to something
+/// real the team stands behind (a genuine field-trial write-up, a technical
+/// explainer, a press mention), never invented data. Unverifiable content is
+/// exactly what CONTRIBUTING.md's no-fake-provenance rule exists to keep off
+/// this site. The /blogs index page keeps the section out of search results
+/// (`noindex`) for as long as this list is empty.
+/// <para>
+/// To publish a post:
+/// 1. Add a <see cref="BlogPostSummary"/> entry below.
+/// 2. Create <c>Pages/Blogs/Posts/{Slug}.razor</c> with
+///    <c>@page "/blogs/{slug}"</c>, following the static-page pattern in
+///    <c>Pages/About.razor</c> (PageTitle, canonical link, meta description,
+///    then content) plus a BlogPosting JSON-LD block — see the VideoObject
+///    blocks in <c>Pages/Home.razor</c> for the ld+json syntax to mirror.
+/// </para>
+/// </summary>
+public static class BlogRegistry
+{
+    public static readonly IReadOnlyList<BlogPostSummary> Posts = [];
+}


### PR DESCRIPTION
## Summary

Partial progress on #70 — see the note below on why it does **not** close the issue.

Most of #70's checklist is off-site business/marketing work with no in-repo fix possible:
- Google Business Profile — requires real business identity verification
- Consistent directory listings — requires actually submitting to real directories
- Captioned YouTube uploads of pond footage — requires an actual channel and video rights
- Trade-press placement — requires real outreach/relationships
- A field-trial write-up with real DO measurements — requires actually measuring a real pond; not something to fabricate (see the no-fake-provenance rule in `CONTRIBUTING.md` from #78/#79)

The one in-repo action item was: *"Then start the `/blogs` section that is already listed in the sitemap."* `/blogs` previously routed to a bare `<ComingSoon/>` placeholder. This PR builds the actual section:

- **`Services/BlogRegistry.cs`** — a small static list of published posts. Starts empty on purpose: no placeholder or fabricated post is added here. Its doc comment explains how the team adds a real one later (mirrors the static-page pattern already used by `Pages/About.razor`).
- **`Pages/Blogs.razor`** — a real index page: heading, lead copy, an empty-state message while there are no posts, and a card grid once there are. Stays `noindex` while empty (an empty page only hurts crawl quality) and switches to `index,follow` automatically the moment the first post is added to the registry. Emits `Blog` JSON-LD once non-empty, matching the structured-data pattern `Home.razor` already uses for video content — the actual point of #70 is making content indexable/quotable by answer engines, which starts with real server-renderable markup, not a "coming soon" placeholder.
- **`Pages/Blogs.razor.css`** — styled consistently with the rest of the marketing site (same kicker/section-title palette as `ResultsSection`/`TechnologySection`).

## Why this doesn't close #70

Both of #70's "done when" criteria are off-site ranking outcomes ("oxyniti" ranks #1 on Google; ChatGPT/Gemini cite the company) that shift only with real off-site signals over weeks/months — no code change makes either one true. This PR unblocks the one piece that was in this repo's control; the rest needs the business/marketing checklist worked outside of it.

## Test plan
- [x] `dotnet build Oxyniti.csproj` — succeeds, 0 warnings/errors.
- [x] Ran the app locally and screenshotted `/blogs`: kicker, heading, lead paragraph and the empty-state box ("The first post is on its way. Check back soon.") all render correctly, header/nav intact, no Blazor error banner.
- [ ] Once a real post is added, manually verify the index switches to `index,follow` and the JSON-LD validates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)