### PR TITLE
Prerender marketing routes, keep WASM only for MAKER routes

### DIFF
--- a/.github/workflows/azure-static-web-apps-deploy.yml
+++ b/.github/workflows/azure-static-web-apps-deploy.yml
@@ -68,8 +68,16 @@ jobs:
       # per-page <lastmod>, and emits routes.json listing every marketing URL
       # for the prerender step below to crawl. Must run before both of the
       # next two steps: they each append to (or read) what this one writes.
+      #
+      # Every --wwwroot/--repo-root/--routes(-out) argument below is passed
+      # as an absolute path ($GITHUB_WORKSPACE-rooted), not a path relative
+      # to this job's working directory: `dotnet run --project <dir>` does
+      # not reliably run the launched app from the invoking shell's working
+      # directory -- it can run from <dir> instead, which silently resolved
+      # every relative path here against tools/Prerender/ instead of the
+      # repo root the first time this workflow ran.
       - name: Generate sitemap.xml + prerender route list
-        run: dotnet run --project tools/StaticSiteMeta/StaticSiteMeta.csproj -c Release -- --wwwroot bin/Release/publish/wwwroot --repo-root . --routes-out bin/Release/prerender-routes.json
+        run: dotnet run --project tools/StaticSiteMeta/StaticSiteMeta.csproj -c Release -- --wwwroot "$GITHUB_WORKSPACE/bin/Release/publish/wwwroot" --repo-root "$GITHUB_WORKSPACE" --routes-out "$GITHUB_WORKSPACE/bin/Release/prerender-routes.json"
 
       # Issue #63: every marketing route shipped nothing but the pre-boot
       # shell until the 2.7 MB Blazor WASM runtime downloaded and booted --
@@ -86,7 +94,7 @@ jobs:
           pwsh tools/Prerender/bin/Release/net9.0/playwright.ps1 install --with-deps chromium
 
       - name: Prerender marketing routes
-        run: dotnet run --project tools/Prerender/Prerender.csproj -c Release --no-build -- --wwwroot bin/Release/publish/wwwroot --routes bin/Release/prerender-routes.json
+        run: dotnet run --project tools/Prerender/Prerender.csproj -c Release --no-build -- --wwwroot "$GITHUB_WORKSPACE/bin/Release/publish/wwwroot" --routes "$GITHUB_WORKSPACE/bin/Release/prerender-routes.json"
 
       # Issue #65: /product/{slug} shipped nothing but a loading skeleton
       # until the Blazor runtime booted and called MakerClient -- no name,
@@ -101,7 +109,7 @@ jobs:
       # sees; the Blazor app then mounts over the same #app root and
       # hydrates the live, interactive page on top.
       - name: Generate static product pages + sitemap entries
-        run: dotnet run --project tools/StaticProductPages/StaticProductPages.csproj -c Release -- --wwwroot bin/Release/publish/wwwroot
+        run: dotnet run --project tools/StaticProductPages/StaticProductPages.csproj -c Release -- --wwwroot "$GITHUB_WORKSPACE/bin/Release/publish/wwwroot"
 
       # Same idea as the wwwroot/images budget above, for the .NET payload. The
       # ceiling is ~3% over the size achieved by #35, so a regression fails the

--- a/.github/workflows/azure-static-web-apps-deploy.yml
+++ b/.github/workflows/azure-static-web-apps-deploy.yml
@@ -64,30 +64,42 @@ jobs:
         run: dotnet publish -c Release -o ./bin/Release/publish
 
       # Issue #69: sitemap.xml was hand-maintained (drifting from the real
-      # route table) and every page shared one og:title/description/twitter
-      # set from index.html, so a WhatsApp/social share of any two pages
-      # previewed identically. This (re)generates sitemap.xml from the route
-      # table with a real per-page <lastmod>, and clones index.html per
-      # marketing route with that page's own title/description swapped into
-      # <title>, the description meta, og:*/twitter:* and a <link
-      # rel="canonical"> (App.razor otherwise only sets canonical after the
-      # WASM runtime boots -- invisible to a share-preview scraper, which
-      # never runs JS). Must run before the product-pages step below: that
-      # step appends to whatever sitemap.xml already exists, and this step
-      # writes sitemap.xml from scratch.
-      - name: Generate sitemap.xml + per-page social tags
-        run: dotnet run --project tools/StaticSiteMeta/StaticSiteMeta.csproj -c Release -- --wwwroot bin/Release/publish/wwwroot --repo-root .
+      # route table). This (re)generates it from the route table with a real
+      # per-page <lastmod>, and emits routes.json listing every marketing URL
+      # for the prerender step below to crawl. Must run before both of the
+      # next two steps: they each append to (or read) what this one writes.
+      - name: Generate sitemap.xml + prerender route list
+        run: dotnet run --project tools/StaticSiteMeta/StaticSiteMeta.csproj -c Release -- --wwwroot bin/Release/publish/wwwroot --repo-root . --routes-out bin/Release/prerender-routes.json
+
+      # Issue #63: every marketing route shipped nothing but the pre-boot
+      # shell until the 2.7 MB Blazor WASM runtime downloaded and booted --
+      # the LCP ceiling (#46) and the reason nothing but the homepage hero
+      # existed in raw HTML for a crawler. This boots a headless Chromium
+      # against each marketing route (routes.json, from the step above),
+      # captures the fully-rendered page -- title, description, canonical,
+      # JSON-LD and body content all produced by the real Razor components --
+      # and strips the WASM loader out before writing it to disk. See
+      # tools/Prerender/Prerender.csproj for the full rationale.
+      - name: Install Playwright's Chromium (for the prerender step)
+        run: |
+          dotnet build tools/Prerender/Prerender.csproj -c Release
+          pwsh tools/Prerender/bin/Release/net9.0/playwright.ps1 install --with-deps chromium
+
+      - name: Prerender marketing routes
+        run: dotnet run --project tools/Prerender/Prerender.csproj -c Release --no-build -- --wwwroot bin/Release/publish/wwwroot --routes bin/Release/prerender-routes.json
 
       # Issue #65: /product/{slug} shipped nothing but a loading skeleton
       # until the Blazor runtime booted and called MakerClient -- no name,
       # price, spec or image in the HTML, and no product URL in sitemap.xml.
       # This pulls the live catalogue and writes a real
       # product/{slug}/index.html straight into the publish output, plus the
-      # matching sitemap.xml entries. Static Web Apps serves a matching file
-      # before it ever falls back to index.html, so these are what a crawler
-      # (or a browser with JS disabled) sees; the Blazor app then mounts over
-      # the same #app root and hydrates the live, interactive page on top,
-      # same as the homepage's existing static shell.
+      # matching sitemap.xml entries. Product pages keep the WASM loader
+      # (unlike the routes prerendered above) -- MakerClient/auth/Stripe/cart
+      # still need it, per issue #63's own scope. Static Web Apps serves a
+      # matching file before it ever falls back to app-shell.html, so this
+      # static content is what a crawler (or a browser with JS disabled)
+      # sees; the Blazor app then mounts over the same #app root and
+      # hydrates the live, interactive page on top.
       - name: Generate static product pages + sitemap entries
         run: dotnet run --project tools/StaticProductPages/StaticProductPages.csproj -c Release -- --wwwroot bin/Release/publish/wwwroot
 

--- a/Layout/MainLayout.razor
+++ b/Layout/MainLayout.razor
@@ -55,7 +55,7 @@
                     <i class="bi bi-globe2"></i>
                 </span>
 
-                <select class="language-select"
+                <select id="language-select" class="language-select"
                         value="@Loc.CurrentLanguage"
                         @onchange="OnLanguageChanged"
                         aria-label="@Loc.T("nav.langSelect", "Website language")">

--- a/Pages/Components/FieldFootageSection.razor
+++ b/Pages/Components/FieldFootageSection.razor
@@ -16,7 +16,8 @@
          genuinely real footage. -->
     <div class="footage-grid">
         <div class="footage-card video-card">
-            <video @ref="_videoElement" muted loop playsinline poster="/images/plume-poster.jpg">
+            <video @ref="_videoElement" muted loop playsinline poster="/images/plume-poster.jpg"
+                   data-video-init="lazy">
                 <source data-src="/videos/plume-portrait.webm" type="video/webm" />
                 <source data-src="/videos/plume-portrait.mp4" type="video/mp4" />
             </video>

--- a/Pages/Components/FreeDemoSection.razor
+++ b/Pages/Components/FreeDemoSection.razor
@@ -43,31 +43,37 @@
         </div>
 
         <div class="demo-form">
-        <EditForm Model="@model" OnValidSubmit="HandleValidSubmit">
+        <!-- id/name/data-field on every control: issue #63 replaces Blazor's
+             EditForm two-way binding with a small vanilla-JS submit handler
+             (wwwroot/js/marketingIslands.js) on the prerendered, WASM-free
+             copy of this page. Blazor doesn't render a `name` attribute for
+             @bind-Value inputs, so without these the JS handler would have
+             no reliable way to tell the fields apart. -->
+        <EditForm Model="@model" OnValidSubmit="HandleValidSubmit" id="free-demo-form">
             <DataAnnotationsValidator />
             <div class="form-grid">
                 <div class="field">
-                    <label>@Loc.T("f.name", "Your name")</label>
-                    <InputText @bind-Value="model.Name" placeholder="@Loc.T("f.name.ph", "e.g. Murugan")" />
+                    <label for="demo-name">@Loc.T("f.name", "Your name")</label>
+                    <InputText id="demo-name" name="name" autocomplete="name" data-field="name" @bind-Value="model.Name" placeholder="@Loc.T("f.name.ph", "e.g. Murugan")" />
                     <ValidationMessage For="@(() => model.Name)" />
                 </div>
                 <div class="field">
-                    <label>@Loc.T("f.phone", "Phone / WhatsApp")</label>
-                    <InputText @bind-Value="model.Phone" placeholder="+91 ..." />
+                    <label for="demo-phone">@Loc.T("f.phone", "Phone / WhatsApp")</label>
+                    <InputText id="demo-phone" name="phone" autocomplete="tel" data-field="phone" @bind-Value="model.Phone" placeholder="+91 ..." />
                     <ValidationMessage For="@(() => model.Phone)" />
                 </div>
                 <div class="field">
-                    <label>@Loc.T("f.place", "Village / Town")</label>
-                    <InputText @bind-Value="model.Place" placeholder="@Loc.T("f.place.ph", "e.g. Lalgudi, Trichy")" />
+                    <label for="demo-place">@Loc.T("f.place", "Village / Town")</label>
+                    <InputText id="demo-place" name="place" data-field="place" @bind-Value="model.Place" placeholder="@Loc.T("f.place.ph", "e.g. Lalgudi, Trichy")" />
                     <ValidationMessage For="@(() => model.Place)" />
                 </div>
                 <div class="field full">
                     <label>@Loc.T("f.map", "Pond location (tap the map to mark it — optional)")</label>
-                    <div id="@mapId" class="demo-picker-map"></div>
+                    <div id="@mapId" class="demo-picker-map" data-demo-map="true"></div>
                 </div>
                 <div class="field">
-                    <label>@Loc.T("f.size", "Pond size")</label>
-                    <InputSelect @bind-Value="model.Size">
+                    <label for="demo-size">@Loc.T("f.size", "Pond size")</label>
+                    <InputSelect id="demo-size" name="size" data-field="size" @bind-Value="model.Size">
                         <option>@Loc.T("o.size1", "Under ½ acre")</option>
                         <option selected>@Loc.T("o.size2", "½ – 1 acre")</option>
                         <option>@Loc.T("o.size3", "1 – 3 acres")</option>
@@ -75,8 +81,8 @@
                     </InputSelect>
                 </div>
                 <div class="field full">
-                    <label>@Loc.T("f.species", "What do you farm?")</label>
-                    <InputSelect @bind-Value="model.Species">
+                    <label for="demo-species">@Loc.T("f.species", "What do you farm?")</label>
+                    <InputSelect id="demo-species" name="species" data-field="species" @bind-Value="model.Species">
                         <option selected>@Loc.T("o.sp1", "Tilapia / GIFT")</option>
                         <option>@Loc.T("o.sp2", "Murrel (Viral meen)")</option>
                         <option>@Loc.T("o.sp3", "Pangasius")</option>
@@ -92,7 +98,7 @@
             {
                 <p class="form-status">@statusMessage</p>
             }
-            <p class="form-note">@Loc.T("f.note", "We respect your privacy — no spam, ever.")</p>
+            <p class="form-note" data-field="note">@Loc.T("f.note", "We respect your privacy — no spam, ever.")</p>
         </EditForm>
         </div>
     </div>

--- a/Pages/Components/Hero.razor
+++ b/Pages/Components/Hero.razor
@@ -6,7 +6,8 @@
 <div class="hero-container">
     <img @ref="_posterElement" class="hero-poster" src="/images/hero-poster-wide.avif" width="1280" height="720"
          fetchpriority="high" decoding="async" alt="" />
-    <video @ref="_videoElement" class="hero-video" muted loop playsinline poster="/images/hero-poster-wide.jpg">
+    <video @ref="_videoElement" class="hero-video" muted loop playsinline poster="/images/hero-poster-wide.jpg"
+           data-video-init="lazy-eager">
         <source data-src="/videos/hero.webm" type="video/webm" />
         <source data-src="/videos/hero.mp4" type="video/mp4" />
     </video>

--- a/Pages/Components/ProfitCalculatorSection.razor
+++ b/Pages/Components/ProfitCalculatorSection.razor
@@ -11,29 +11,29 @@
 
             <div class="slider-row">
                 <div class="row-head">
-                    <label>@Loc.T("roi.size", "Pond size")</label>
-                    <output>@AcresLabel</output>
+                    <label for="calc-acres">@Loc.T("roi.size", "Pond size")</label>
+                    <output id="calc-acres-label">@AcresLabel</output>
                 </div>
-                <input type="range" min="0.5" max="5" step="0.5" value="@Acres"
+                <input id="calc-acres" type="range" min="0.5" max="5" step="0.5" value="@Acres"
                        @oninput="OnAcresChanged" />
             </div>
 
             <div class="slider-row">
                 <div class="row-head">
-                    <label>@Loc.T("roi.price", "Farm-gate price")</label>
-                    <output>@PriceLabel</output>
+                    <label for="calc-price">@Loc.T("roi.price", "Farm-gate price")</label>
+                    <output id="calc-price-label">@PriceLabel</output>
                 </div>
-                <input type="range" min="80" max="400" step="10" value="@PricePerKg"
+                <input id="calc-price" type="range" min="80" max="400" step="10" value="@PricePerKg"
                        @oninput="OnPriceChanged" />
             </div>
         </div>
 
         <div class="calc-right">
             <span class="lbl">@Loc.T("roi.harv", "Estimated extra harvest")</span>
-            <div class="kg">+@LowKg.ToString("N0") &ndash; @HighKg.ToString("N0") @Loc.T("roi.kgyr", "kg / year")</div>
+            <div id="calc-kg" class="kg">+@LowKg.ToString("N0") &ndash; @HighKg.ToString("N0") @Loc.T("roi.kgyr", "kg / year")</div>
             <hr />
             <span class="lbl">@Loc.T("roi.rev", "Estimated extra revenue")</span>
-            <div class="value">@FmtInr(LowRevenue) &ndash; @FmtInr(HighRevenue)</div>
+            <div id="calc-revenue" class="value">@FmtInr(LowRevenue) &ndash; @FmtInr(HighRevenue)</div>
             <p class="note">
                 @Loc.T("roi.note", "Illustrative only — assumes a semi-intensive baseline of ~2,500 kg/acre/year and a 20–30% yield uplift from improved DO, survival and FCR (range reported in published nano-bubble aquaculture studies). We validate real numbers on your pond during the free demo.")
             </p>

--- a/Pages/Components/SkyViewSection.razor
+++ b/Pages/Components/SkyViewSection.razor
@@ -18,7 +18,8 @@
                loop
                playsinline
                preload="none"
-               poster="/images/drone-poster.jpg">
+               poster="/images/drone-poster.jpg"
+               data-video-init="drone-stage">
             <source data-src="/videos/drone.webm" type="video/webm" />
             <source data-src="/videos/drone.mp4" type="video/mp4" />
         </video>

--- a/tools/Prerender/Prerender.csproj
+++ b/tools/Prerender/Prerender.csproj
@@ -1,0 +1,67 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <!--
+    Build-time prerenderer for issue #63: every marketing route shipped
+    nothing but the pre-boot shell until the 2.7 MB Blazor WASM runtime
+    downloaded and booted — the LCP ceiling (#46), the reason nothing but
+    the homepage hero existed in raw HTML for a crawler, and the reason the
+    per-page title/description/canonical tools/StaticSiteMeta wrote (#69)
+    could never be more than a hand-maintained approximation of what the real
+    page would say once Blazor actually rendered it.
+
+    This tool runs after `dotnet publish`, before tools/StaticSiteMeta (which
+    now only regenerates sitemap.xml, see that tool's own comment) and
+    tools/StaticProductPages. It:
+      1. Copies the published wwwroot/index.html (the real WASM-booting
+         shell) to wwwroot/app-shell.html before anything below starts
+         overwriting index.html. staticwebapp.config.json's
+         navigationFallback now rewrites unmatched routes to this file
+         instead of index.html, so every route this tool does not cover
+         (/cart, /account, /checkout, /login; /product/{slug} is handled
+         separately by StaticProductPages and keeps its own copy of the
+         WASM loader) still boots Blazor exactly as before.
+      2. Serves the published wwwroot from a local Kestrel instance, so
+         headless Chromium can boot the real app the same way a live
+         visitor's browser would.
+      3. Boots a headless Chromium (Microsoft.Playwright) against each route
+         named in the routes.json that tools/StaticSiteMeta emits (its own
+         route table, so the two tools can't drift), waits for the page to
+         settle, and captures the fully-rendered DOM: title, meta
+         description, canonical, JSON-LD and all of it produced by the real
+         Razor components, not a regex approximation of them.
+      4. Strips the blazor.webassembly.js script tag (and the blazor-error-ui
+         bootstrap it's paired with) out of the captured HTML before writing
+         it to disk. That's the actual fix: the page a real visitor's
+         browser parses on first paint never requests the WASM runtime at
+         all. The other small vanilla-JS-driven bits these pages need (the
+         profit calculator, the free-demo form, the language switcher,
+         scroll-spy, tank-bubble/testimonial/map decoration; issue #63's
+         "island-sized" components) are wired by
+         wwwroot/js/marketingIslands.js, loaded on every prerendered page;
+         see that file for what it does and why each piece is safe to run
+         without a live Blazor circuit.
+
+    Deliberately not part of Oxyniti.sln / Oxyniti.csproj, for the same
+    reason as its sibling tools: the workflow's `dotnet build`/`dotnet
+    publish` (no explicit project) resolve to the one app project today, and
+    folding a second publishable project into that would split publish
+    output between two folders. Sdk.Web (not the plain Sdk) only because it
+    needs Kestrel and static-file serving to stand up the local server in
+    step 2.
+  -->
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <RootNamespace>Oxyniti.Prerender</RootNamespace>
+    <InvariantGlobalization>true</InvariantGlobalization>
+    <NoDefaultLaunchSettingsFile>true</NoDefaultLaunchSettingsFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Playwright" Version="1.49.0" />
+  </ItemGroup>
+
+</Project>

--- a/tools/Prerender/Program.cs
+++ b/tools/Prerender/Program.cs
@@ -1,3 +1,4 @@
+using System.IO.Compression;
 using System.Net;
 using System.Text;
 using System.Text.Json;
@@ -56,7 +57,20 @@ internal static partial class Program
             return 1;
         }
 
-        File.Copy(indexPath, appShellPath, overwrite: true);
+        // `dotnet publish` pre-compresses index.html into index.html.br /
+        // index.html.gz at build time (Blazor's static web asset
+        // compression); Static Web Apps prefers serving those precompressed
+        // siblings over compressing index.html itself on the fly. Every
+        // real browser negotiates Brotli, so if this loop below only ever
+        // overwrites the *uncompressed* index.html (and every other route's
+        // own output file), visitors keep getting served the stale,
+        // Blazor-booting .br file forever -- silently undoing this entire
+        // fix for anyone but a client (like plain curl) that skips
+        // compression negotiation. WriteHtmlFile (below) always regenerates
+        // both compressed siblings alongside the plain file for exactly
+        // this reason, for every file this tool writes -- app-shell.html
+        // included, even though it never had stale siblings to begin with.
+        WriteHtmlFile(appShellPath, await File.ReadAllBytesAsync(indexPath));
 
         // The local server's SPA fallback (below) must serve app-shell.html,
         // not index.html: this loop overwrites index.html (and every other
@@ -79,7 +93,7 @@ internal static partial class Program
                 var html = await CaptureAsync(page, server.BaseAddress, route.Path);
                 var outputPath = Path.Combine(wwwroot, route.OutputRelPath.Replace('/', Path.DirectorySeparatorChar));
                 Directory.CreateDirectory(Path.GetDirectoryName(outputPath)!);
-                File.WriteAllText(outputPath, html, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+                WriteHtmlFile(outputPath, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false).GetBytes(html));
                 Console.WriteLine($"[prerender] {route.Path} -> {route.OutputRelPath} ({html.Length:N0} chars)");
             }
             catch (Exception ex)
@@ -104,6 +118,25 @@ internal static partial class Program
     {
         var idx = Array.IndexOf(args, name);
         return idx >= 0 && idx + 1 < args.Length ? args[idx + 1] : null;
+    }
+
+    // Writes `path` plus fresh `path.br` / `path.gz` siblings, matching what
+    // `dotnet publish`'s own static web asset compression produces for
+    // everything else in wwwroot -- see the comment where this is first
+    // called for why skipping the compressed siblings is actively wrong,
+    // not just a missed optimisation, for a file this tool overwrites.
+    private static void WriteHtmlFile(string path, byte[] bytes)
+    {
+        File.WriteAllBytes(path, bytes);
+        WriteCompressed(path + ".br", bytes, stream => new BrotliStream(stream, CompressionLevel.Optimal));
+        WriteCompressed(path + ".gz", bytes, stream => new GZipStream(stream, CompressionLevel.Optimal));
+    }
+
+    private static void WriteCompressed(string path, byte[] bytes, Func<Stream, Stream> makeCompressor)
+    {
+        using var fileStream = File.Create(path);
+        using var compressor = makeCompressor(fileStream);
+        compressor.Write(bytes, 0, bytes.Length);
     }
 
     // Boots the real Blazor app for this route (WASM and all -- the only way

--- a/tools/Prerender/Program.cs
+++ b/tools/Prerender/Program.cs
@@ -1,0 +1,352 @@
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Text.RegularExpressions;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting.Server;
+using Microsoft.AspNetCore.Hosting.Server.Features;
+using Microsoft.AspNetCore.StaticFiles;
+using Microsoft.Extensions.FileProviders;
+using Microsoft.Playwright;
+
+namespace Oxyniti.Prerender;
+
+// See the comment at the top of Prerender.csproj for what this does and why.
+// Run: dotnet run --project tools/Prerender -- --wwwroot <path> --routes <path>
+internal static partial class Program
+{
+    private static async Task<int> Main(string[] args)
+    {
+        var wwwroot = Path.GetFullPath(GetArg(args, "--wwwroot") ?? Path.Combine("bin", "Release", "publish", "wwwroot"));
+        var routesPath = GetArg(args, "--routes");
+
+        if (!Directory.Exists(wwwroot))
+        {
+            Console.Error.WriteLine($"[prerender] wwwroot not found at '{wwwroot}'.");
+            return 1;
+        }
+
+        if (string.IsNullOrEmpty(routesPath) || !File.Exists(routesPath))
+        {
+            Console.Error.WriteLine($"[prerender] --routes not found at '{routesPath ?? "(none given)"}'. Run tools/StaticSiteMeta first -- it emits this file.");
+            return 1;
+        }
+
+        var routes = JsonSerializer.Deserialize<List<RouteEntry>>(
+            File.ReadAllText(routesPath),
+            new JsonSerializerOptions { PropertyNameCaseInsensitive = true })
+            ?? throw new InvalidOperationException($"Couldn't parse routes file '{routesPath}'.");
+
+        if (routes.Count == 0)
+        {
+            Console.Error.WriteLine("[prerender] Route list is empty, nothing to do.");
+            return 1;
+        }
+
+        // Preserve the real WASM-booting shell *before* anything below starts
+        // overwriting index.html -- this becomes staticwebapp.config.json's
+        // navigationFallback target, so every route this tool doesn't cover
+        // (app routes: /cart, /account, /login, etc.) still boots Blazor.
+        var indexPath = Path.Combine(wwwroot, "index.html");
+        var appShellPath = Path.Combine(wwwroot, "app-shell.html");
+        if (!File.Exists(indexPath))
+        {
+            Console.Error.WriteLine($"[prerender] index.html not found at '{indexPath}'.");
+            return 1;
+        }
+
+        File.Copy(indexPath, appShellPath, overwrite: true);
+
+        // The local server's SPA fallback (below) must serve app-shell.html,
+        // not index.html: this loop overwrites index.html (and every other
+        // route's own output file) on disk as it goes, in the same wwwroot
+        // the server is reading from -- app-shell.html is the one file the
+        // rest of this run never touches, so it's the only safe thing to
+        // fall back to for every route captured after the first.
+        await using var server = await LocalWwwrootServer.StartAsync(wwwroot, appShellPath);
+
+        using var playwright = await Playwright.CreateAsync();
+        await using var browser = await playwright.Chromium.LaunchAsync(new BrowserTypeLaunchOptions { Headless = true });
+        var page = await browser.NewPageAsync();
+
+        var failures = new List<string>();
+
+        foreach (var route in routes)
+        {
+            try
+            {
+                var html = await CaptureAsync(page, server.BaseAddress, route.Path);
+                var outputPath = Path.Combine(wwwroot, route.OutputRelPath.Replace('/', Path.DirectorySeparatorChar));
+                Directory.CreateDirectory(Path.GetDirectoryName(outputPath)!);
+                File.WriteAllText(outputPath, html, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+                Console.WriteLine($"[prerender] {route.Path} -> {route.OutputRelPath} ({html.Length:N0} chars)");
+            }
+            catch (Exception ex)
+            {
+                failures.Add($"{route.Path}: {ex.Message}");
+                Console.Error.WriteLine($"[prerender] Failed to capture '{route.Path}': {ex}");
+            }
+        }
+
+        if (failures.Count > 0)
+        {
+            Console.Error.WriteLine($"[prerender] {failures.Count} of {routes.Count} route(s) failed:");
+            foreach (var f in failures) Console.Error.WriteLine($"  - {f}");
+            return 1;
+        }
+
+        Console.WriteLine($"[prerender] Wrote {routes.Count} prerendered page(s).");
+        return 0;
+    }
+
+    private static string? GetArg(string[] args, string name)
+    {
+        var idx = Array.IndexOf(args, name);
+        return idx >= 0 && idx + 1 < args.Length ? args[idx + 1] : null;
+    }
+
+    // Boots the real Blazor app for this route (WASM and all -- the only way
+    // to get output that's actually faithful to what the Razor components
+    // render, JSON-LD/title/meta included) and captures the settled DOM.
+    private static async Task<string> CaptureAsync(IPage page, string baseAddress, string routePath)
+    {
+        var url = baseAddress.TrimEnd('/') + routePath;
+
+        try
+        {
+            await page.GotoAsync(url, new PageGotoOptions
+            {
+                WaitUntil = WaitUntilState.NetworkIdle,
+                Timeout = 20_000,
+            });
+        }
+        catch (TimeoutException)
+        {
+            // Fine on a page that keeps some background poll alive (e.g. the
+            // live BusinessInfo call against a cold-starting external API --
+            // see issue #26, still open) -- fall back to "DOM loaded" plus a
+            // fixed settle delay rather than failing the whole build over an
+            // unrelated external dependency's own flakiness.
+            await page.WaitForLoadStateAsync(LoadState.Load);
+        }
+
+        // Blazor's own render + JS interop (scroll-spy init, tank-bubble
+        // start, etc.) can still be finishing a beat after the network goes
+        // idle; this is a build-time step, not a user's page load, so a
+        // fixed settle cost here is the right trade against flakiness.
+        await page.WaitForTimeoutAsync(500);
+
+        var html = await page.ContentAsync();
+        html = StripBlazorLoader(html, routePath);
+        return NormalizeHeadMeta(html, routePath);
+    }
+
+    private const string Origin = "https://www.oxyniti.com";
+
+    // Two head-rendering gaps that only show up once a page is actually
+    // captured post-boot (neither existed in the old regex-on-a-template
+    // approach this replaces, tools/StaticSiteMeta's now-removed
+    // RenderPage -- see that tool's own comment):
+    //
+    //  1. App.razor's self-referencing <link rel="canonical"> is emitted
+    //     from a <HeadContent> declared directly inside the Router's
+    //     <Found> template (not a page component's own markup).
+    //     Empirically, that specific HeadContent never survives to the
+    //     final DOM on any route whose page also runs the
+    //     locale-resolution OnParametersSetAsync logic (About, Technology,
+    //     Home, etc.) -- only the three plain pages without it
+    //     (Privacy/Terms/Sitemap) keep their canonical tag. That looks
+    //     like a genuine Blazor HeadOutlet ordering bug worth its own
+    //     issue, but root-causing WASM head-rendering internals is out of
+    //     scope here.
+    //  2. <meta name="description"> is duplicated: the site-wide default
+    //     baked into wwwroot/index.html is never removed, and each page's
+    //     own <HeadContent> meta description is simply appended after it
+    //     by HeadOutlet -- so two <meta name="description"> tags exist,
+    //     and per HTML convention crawlers use the first (wrong) one, not
+    //     the page-specific (right) one that's second. og:description,
+    //     twitter:description, og:title and twitter:title never update at
+    //     all: nothing in the app sets them via HeadContent, so they stay
+    //     on index.html's site-wide defaults on every route.
+    //
+    // tools/Prerender already knows (or can read straight out of the
+    // captured DOM) the correct value for every one of these, so it's
+    // simpler and more robust to assert them directly here than to depend
+    // on runtime behaviour that -- per the above -- doesn't reliably do it.
+    private static string NormalizeHeadMeta(string html, string routePath)
+    {
+        var canonicalUrl = routePath == "/" ? Origin + "/" : Origin + routePath;
+
+        // Extracted from text-node content (HTML-entity-decoded by nothing
+        // yet), about to be reused inside an attribute value -- re-encode
+        // for that context (a literal '"' in a title would otherwise break
+        // the attribute it's spliced into).
+        var titleMatch = TitleRegex().Match(html);
+        var title = titleMatch.Success ? WebUtility.HtmlEncode(WebUtility.HtmlDecode(titleMatch.Groups[1].Value)) : "";
+
+        var descriptionMatches = MetaDescriptionRegex().Matches(html);
+        if (descriptionMatches.Count > 1)
+        {
+            // Keep only the last (most specific) one, drop the rest.
+            for (var i = 0; i < descriptionMatches.Count - 1; i++)
+            {
+                html = html.Replace(descriptionMatches[i].Value, "");
+            }
+        }
+
+        var description = descriptionMatches.Count > 0
+            ? descriptionMatches[^1].Groups[1].Value
+            : "";
+
+        html = ReplaceMetaContent(html, "og:title", title);
+        html = ReplaceMetaContent(html, "og:description", description);
+        html = ReplaceMetaContent(html, "og:url", WebUtility.HtmlEncode(canonicalUrl));
+        html = ReplaceMetaContent(html, "twitter:title", title);
+        html = ReplaceMetaContent(html, "twitter:description", description);
+
+        if (!CanonicalLinkRegex().IsMatch(html))
+        {
+            var tag = $"    <link rel=\"canonical\" href=\"{WebUtility.HtmlEncode(canonicalUrl)}\" />\n";
+            html = HeadCloseRegex().Replace(html, tag + "</head>", 1);
+        }
+
+        return html;
+    }
+
+    // `property` covers both `property="og:..."` and `name="twitter:..."`
+    // metas -- the attribute name differs but the shape (one `content="..."`
+    // to swap) doesn't.
+    private static string ReplaceMetaContent(string html, string property, string encodedValue)
+    {
+        if (string.IsNullOrEmpty(encodedValue)) return html;
+
+        var regex = MetaPropertyRegex(Regex.Escape(property));
+        return regex.Replace(html, m => m.Value.Replace(m.Groups[1].Value, encodedValue), 1);
+    }
+
+    private static Regex MetaPropertyRegex(string escapedProperty) =>
+        new($"""<meta (?:property|name)="{escapedProperty}" content="([^"]*)"\s*/?>""");
+
+    [GeneratedRegex("""<title>(.*?)</title>""")]
+    private static partial Regex TitleRegex();
+
+    [GeneratedRegex("""<meta name="description" content="([^"]*)"\s*/?>""")]
+    private static partial Regex MetaDescriptionRegex();
+
+    [GeneratedRegex("""<link[^>]*rel="canonical"[^>]*>""")]
+    private static partial Regex CanonicalLinkRegex();
+
+    [GeneratedRegex("""</head>""")]
+    private static partial Regex HeadCloseRegex();
+
+    // The one actual fix: a browser parsing this file must never request the
+    // WASM runtime. Throws instead of silently no-op'ing (matching
+    // tools/StaticSiteMeta's ReplaceRequired) so a future change to
+    // wwwroot/index.html's boot script markup gets caught by CI immediately,
+    // rather than these "static" pages quietly shipping Blazor again.
+    private static string StripBlazorLoader(string html, string routePath)
+    {
+        if (!BlazorScriptRegex().IsMatch(html))
+        {
+            throw new InvalidOperationException(
+                $"Expected to find and strip the blazor.webassembly.js <script> tag in the captured output for '{routePath}', but it wasn't there.");
+        }
+
+        // Swapped 1:1 for the vanilla-JS island bootstrap: everything on
+        // these pages that used to be a Blazor event handler (the profit
+        // calculator, the free-demo form, the language switcher, nav
+        // scroll-spy, tank-bubble/testimonial/map/QR/video decoration) is
+        // wired there instead. See that file's own header comment.
+        html = BlazorScriptRegex().Replace(html, "    <script src=\"/js/marketingIslands.js\" defer></script>\n");
+
+        // Paired with it in wwwroot/index.html's inline bootstrap script (see
+        // that file); meaningless without a Blazor runtime to ever show it.
+        html = BlazorErrorUiScriptRegex().Replace(html, "");
+        html = BlazorErrorUiDivRegex().Replace(html, "");
+
+        // Belt-and-braces: strip anything else under _framework/ that the
+        // Blazor runtime itself may have injected into <head> while booting
+        // (e.g. modulepreload hints for lazily-loaded assemblies). Any such
+        // tag surviving into the shipped file would be *worse* than doing
+        // nothing -- a preload hint for a multi-MB asset nobody on this page
+        // will ever load is exactly the bandwidth cost #63 removes.
+        html = FrameworkAssetTagRegex().Replace(html, "");
+
+        return html;
+    }
+
+    [GeneratedRegex("""<script[^>]*src="[^"]*_framework/blazor\.webassembly\.js"[^>]*>\s*</script>\n?""")]
+    private static partial Regex BlazorScriptRegex();
+
+    [GeneratedRegex("""<(script|link)[^>]*(?:src|href)="[^"]*_framework/[^"]*"[^>]*>(?:\s*</script>)?\n?""")]
+    private static partial Regex FrameworkAssetTagRegex();
+
+    [GeneratedRegex("""<script>\s*\(function \(\) \{\s*// Created here.*?\}\)\(\);\s*</script>\n?""", RegexOptions.Singleline)]
+    private static partial Regex BlazorErrorUiScriptRegex();
+
+    [GeneratedRegex("""<div id="blazor-error-ui"[^>]*data-nosnippet[^>]*>.*?</div>\n?""", RegexOptions.Singleline)]
+    private static partial Regex BlazorErrorUiDivRegex();
+}
+
+internal sealed class RouteEntry
+{
+    [JsonPropertyName("path")] public string Path { get; set; } = "";
+    [JsonPropertyName("outputRelPath")] public string OutputRelPath { get; set; } = "";
+}
+
+// A minimal local static-file host for the published wwwroot, with the same
+// "serve a matching file, else fall back to the WASM-booting shell" shape
+// Azure Static Web Apps applies in production (navigationFallback) --
+// close enough that navigating Chromium at e.g. "/about" boots the real
+// Blazor Router into the real About.razor, same as a live visitor would get.
+internal sealed class LocalWwwrootServer : IAsyncDisposable
+{
+    private readonly WebApplication _app;
+    public string BaseAddress { get; }
+
+    private LocalWwwrootServer(WebApplication app, string baseAddress)
+    {
+        _app = app;
+        BaseAddress = baseAddress;
+    }
+
+    public static async Task<LocalWwwrootServer> StartAsync(string wwwroot, string spaFallbackPath)
+    {
+        var builder = WebApplication.CreateBuilder(new WebApplicationOptions { EnvironmentName = "Production" });
+        builder.Logging.ClearProviders();
+        builder.WebHost.UseUrls("http://127.0.0.1:0");
+
+        var contentTypeProvider = new FileExtensionContentTypeProvider();
+        // .NET's default map already knows .wasm/.json/.woff2; Blazor's own
+        // publish output also ships a couple of extensionless/less-common
+        // ones that would otherwise 404 or serve with no content-type.
+        contentTypeProvider.Mappings[".dat"] = "application/octet-stream";
+        contentTypeProvider.Mappings[".blat"] = "application/octet-stream";
+        contentTypeProvider.Mappings[".dll"] = "application/octet-stream";
+
+        var app = builder.Build();
+        var fileProvider = new PhysicalFileProvider(wwwroot);
+        app.UseStaticFiles(new StaticFileOptions
+        {
+            FileProvider = fileProvider,
+            ContentTypeProvider = contentTypeProvider,
+            ServeUnknownFileTypes = true,
+        });
+        app.MapFallback(async context =>
+        {
+            context.Response.ContentType = "text/html; charset=utf-8";
+            await context.Response.SendFileAsync(spaFallbackPath);
+        });
+
+        await app.StartAsync();
+
+        var addressFeature = app.Services.GetRequiredService<IServer>().Features.Get<IServerAddressesFeature>()
+            ?? throw new InvalidOperationException("Local server started without a bound address.");
+        var baseAddress = addressFeature.Addresses.First();
+
+        return new LocalWwwrootServer(app, baseAddress);
+    }
+
+    public async ValueTask DisposeAsync() => await _app.DisposeAsync();
+}

--- a/tools/StaticSiteMeta/Program.cs
+++ b/tools/StaticSiteMeta/Program.cs
@@ -1,24 +1,25 @@
-﻿using System.Diagnostics;
+using System.Diagnostics;
 using System.Net;
 using System.Text;
-using System.Text.RegularExpressions;
+using System.Text.Json;
 
 namespace Oxyniti.StaticSiteMeta;
 
 // See the comment at the top of StaticSiteMeta.csproj for what this generates
-// and why. Run: dotnet run --project tools/StaticSiteMeta -- --wwwroot <path> --repo-root <path>
-internal static partial class Program
+// and why. Run: dotnet run --project tools/StaticSiteMeta -- --wwwroot <path> --repo-root <path> --routes-out <path>
+internal static class Program
 {
     private const string Origin = "https://www.oxyniti.com";
 
-    // The route table: every URL sitemap.xml should carry, plus the .razor
-    // file whose <PageTitle>/description own that route's real copy, plus
+    // The route table: every URL sitemap.xml (and tools/Prerender) should
+    // carry, plus the .razor file whose git history sources <lastmod>, plus
     // (for the two pages issue #67 brought online in extra locales) the
     // locale codes whose translation is ready. Mirrors
-    // Services/LocalizedRoutes.cs's ReadyLocales map -- duplicated rather than
-    // referenced because that type lives in the Blazor WASM app project and
-    // this is a separate, plain console project (see the .csproj comment).
-    // If a locale is added there for "about" or "contact", add it here too.
+    // Services/LocalizedRoutes.cs's ReadyLocales map -- duplicated rather
+    // than referenced because that type lives in the Blazor WASM app project
+    // and this is a separate, plain console project (see the .csproj
+    // comment). If a locale is added there for "about" or "contact", add it
+    // here too.
     private static readonly PageRoute[] Routes =
     [
         new("", "Pages/Home.razor", []),
@@ -38,6 +39,7 @@ internal static partial class Program
     {
         var wwwroot = Path.GetFullPath(GetArg(args, "--wwwroot") ?? Path.Combine("bin", "Release", "publish", "wwwroot"));
         var repoRoot = Path.GetFullPath(GetArg(args, "--repo-root") ?? Directory.GetCurrentDirectory());
+        var routesOut = GetArg(args, "--routes-out");
 
         if (!Directory.Exists(wwwroot))
         {
@@ -45,18 +47,8 @@ internal static partial class Program
             return 1;
         }
 
-        var templatePath = Path.Combine(wwwroot, "index.html");
-        if (!File.Exists(templatePath))
-        {
-            Console.Error.WriteLine($"[static-site-meta] index.html not found at '{templatePath}'.");
-            return 1;
-        }
-
-        var template = File.ReadAllText(templatePath);
-        var fallbackDescription = ExtractLiteralMetaDescription(template)
-            ?? throw new InvalidOperationException("Could not find the default <meta name=\"description\"> in index.html to use as a fallback.");
-
         var sitemapGroups = new List<SitemapGroup>();
+        var prerenderRoutes = new List<PrerenderRoute>();
 
         foreach (var route in Routes)
         {
@@ -67,40 +59,41 @@ internal static partial class Program
                 return 1;
             }
 
-            var source = File.ReadAllText(sourcePath);
-            var title = ExtractTitle(source)
-                ?? throw new InvalidOperationException($"Route '{route.Slug}': couldn't extract <PageTitle> from {route.SourceRelPath}.");
-            var description = ExtractMetaDescription(source) ?? fallbackDescription;
-
             var enUrl = route.Slug.Length == 0 ? $"{Origin}/" : $"{Origin}/{route.Slug}";
+            var enPath = route.Slug.Length == 0 ? "/" : $"/{route.Slug}";
             var enLastMod = GitLastModifiedDate(repoRoot, route.SourceRelPath);
 
             var urls = new List<SitemapUrl> { new(enUrl, enLastMod) };
+            prerenderRoutes.Add(new PrerenderRoute(enPath, route.Slug.Length == 0 ? "index.html" : $"{route.Slug}/index.html"));
+
             foreach (var locale in route.ReadyLocales)
             {
                 var localeJson = Path.Combine("wwwroot", "i18n", $"{locale}.json");
                 var localeLastMod = MaxDate(enLastMod, GitLastModifiedDate(repoRoot, localeJson));
                 urls.Add(new($"{Origin}/{locale}/{route.Slug}", localeLastMod));
+
+                var localePath = route.Slug.Length == 0 ? $"/{locale}" : $"/{locale}/{route.Slug}";
+                var localeOutput = route.Slug.Length == 0 ? $"{locale}/index.html" : $"{locale}/{route.Slug}/index.html";
+                prerenderRoutes.Add(new PrerenderRoute(localePath, localeOutput));
             }
 
             var group = new SitemapGroup(urls, route.ReadyLocales.Length > 0 ? [.. route.ReadyLocales] : []);
             sitemapGroups.Add(group);
-
-            // Same reciprocal hreflang set LocaleHead.razor renders at runtime
-            // for this slug (see that component) -- added here too so it's
-            // present before the WASM runtime boots, not just after.
-            var page = RenderPage(template, title, description, enUrl, group.HreflangLinks);
-            var outputPath = route.Slug.Length == 0
-                ? Path.Combine(wwwroot, "index.html")
-                : Path.Combine(wwwroot, route.Slug, "index.html");
-            Directory.CreateDirectory(Path.GetDirectoryName(outputPath)!);
-            File.WriteAllText(outputPath, page, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
         }
 
         var sitemapPath = Path.Combine(wwwroot, "sitemap.xml");
         File.WriteAllText(sitemapPath, RenderSitemap(sitemapGroups), new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
 
-        Console.WriteLine($"[static-site-meta] Wrote {Routes.Length} per-page head override(s) and {sitemapGroups.Sum(g => g.Urls.Count)} sitemap.xml url(s).");
+        Console.WriteLine($"[static-site-meta] Wrote {sitemapGroups.Sum(g => g.Urls.Count)} sitemap.xml url(s).");
+
+        if (!string.IsNullOrEmpty(routesOut))
+        {
+            Directory.CreateDirectory(Path.GetDirectoryName(Path.GetFullPath(routesOut))!);
+            var json = JsonSerializer.Serialize(prerenderRoutes, new JsonSerializerOptions { WriteIndented = true });
+            File.WriteAllText(routesOut, json, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+            Console.WriteLine($"[static-site-meta] Wrote {prerenderRoutes.Count} route(s) to '{routesOut}' for tools/Prerender.");
+        }
+
         return 0;
     }
 
@@ -144,100 +137,6 @@ internal static partial class Program
         return date.UtcDateTime.ToString("yyyy-MM-dd");
     }
 
-    // <PageTitle>literal text</PageTitle> or <PageTitle>@Loc.T("key", "fallback")</PageTitle>.
-    // The Loc.T fallback IS the real English copy (LocalizationService.T renders it
-    // whenever the key is missing/English), so it's exactly the right string to lift.
-    private static string? ExtractTitle(string source)
-    {
-        var locMatch = TitleLocRegex().Match(source);
-        if (locMatch.Success)
-        {
-            return WebUtility.HtmlDecode(locMatch.Groups[1].Value);
-        }
-
-        var literalMatch = TitleLiteralRegex().Match(source);
-        return literalMatch.Success ? WebUtility.HtmlDecode(literalMatch.Groups[1].Value.Trim()) : null;
-    }
-
-    private static string? ExtractMetaDescription(string source)
-    {
-        var locMatch = DescriptionLocRegex().Match(source);
-        if (locMatch.Success)
-        {
-            return WebUtility.HtmlDecode(locMatch.Groups[1].Value);
-        }
-
-        return ExtractLiteralMetaDescription(source);
-    }
-
-    private static string? ExtractLiteralMetaDescription(string source)
-    {
-        var match = DescriptionLiteralRegex().Match(source);
-        return match.Success ? WebUtility.HtmlDecode(match.Groups[1].Value) : null;
-    }
-
-    // Swaps the page-identity fields in a clone of index.html: <title>, the
-    // description meta, og:*/twitter:* title+description, og:url, and a
-    // <link rel="canonical"> (App.razor otherwise only sets one after the
-    // WASM runtime boots -- invisible to a share-preview scraper, which
-    // never runs JS). og:image is left as the site-wide hero: none of these
-    // pages ship a distinct hero photo to source a "1200x630 with the
-    // product visible" crop from (see the PR description) -- a real
-    // per-page image is content/design work, left as a follow-up.
-    private static string RenderPage(string template, string title, string description, string canonicalUrl, List<(string Hreflang, string Href)> hreflangLinks)
-    {
-        var html = template;
-
-        html = ReplaceRequired(html, "<title>Oxyniti</title>", $"<title>{Enc(title)}</title>");
-        html = ReplaceRequired(
-            html,
-            "<meta name=\"description\" content=\"Oxyniti nano-bubble generators supercharge dissolved oxygen in fish ponds — healthier fish, faster growth, higher yield.\" />",
-            $"<meta name=\"description\" content=\"{Enc(description)}\" />");
-        html = ReplaceRequired(
-            html,
-            "<meta property=\"og:title\" content=\"Oxyniti — Infinite Oxygen. Infinite Yield.\" />",
-            $"<meta property=\"og:title\" content=\"{Enc(title)}\" />");
-        html = ReplaceRequired(
-            html,
-            "<meta property=\"og:description\" content=\"Nano-bubble generators that supercharge dissolved oxygen in fish ponds — healthier fish, faster growth, higher yield.\" />",
-            $"<meta property=\"og:description\" content=\"{Enc(description)}\" />");
-        html = ReplaceRequired(
-            html,
-            "<meta property=\"og:url\" content=\"https://www.oxyniti.com/\" />",
-            $"<meta property=\"og:url\" content=\"{Enc(canonicalUrl)}\" />");
-        html = ReplaceRequired(
-            html,
-            "<meta name=\"twitter:title\" content=\"Oxyniti — Infinite Oxygen. Infinite Yield.\" />",
-            $"<meta name=\"twitter:title\" content=\"{Enc(title)}\" />");
-        html = ReplaceRequired(
-            html,
-            "<meta name=\"twitter:description\" content=\"Nano-bubble generators that supercharge dissolved oxygen in fish ponds — healthier fish, faster growth, higher yield.\" />",
-            $"<meta name=\"twitter:description\" content=\"{Enc(description)}\" />");
-        var headExtras = new StringBuilder();
-        headExtras.Append($"\n\n    <link rel=\"canonical\" href=\"{Enc(canonicalUrl)}\" />");
-        foreach (var (hreflang, href) in hreflangLinks)
-        {
-            headExtras.Append($"\n    <link rel=\"alternate\" hreflang=\"{Enc(hreflang)}\" href=\"{Enc(href)}\" />");
-        }
-
-        html = ReplaceRequired(html, "<base href=\"/\" />", $"<base href=\"/\" />{headExtras}");
-
-        return html;
-    }
-
-    // Throws instead of silently no-op'ing so a future edit to index.html's
-    // wording gets caught by CI immediately, rather than these routes quietly
-    // reverting to the site-wide meta with no visible symptom.
-    private static string ReplaceRequired(string html, string oldValue, string newValue)
-    {
-        if (!html.Contains(oldValue, StringComparison.Ordinal))
-        {
-            throw new InvalidOperationException($"Expected to find and replace this in index.html, but it wasn't there any more:\n{oldValue}");
-        }
-
-        return html.Replace(oldValue, newValue);
-    }
-
     private static string Enc(string value) => WebUtility.HtmlEncode(value);
 
     // No <priority> (Google ignores it -- already dropped in the partial #69
@@ -267,23 +166,16 @@ internal static partial class Program
         sb.Append("</urlset>\n");
         return sb.ToString();
     }
-
-    [GeneratedRegex("""<PageTitle>\s*@Loc\.T\("[^"]+",\s*"((?:[^"\\]|\\.)*)"\)\s*</PageTitle>""")]
-    private static partial Regex TitleLocRegex();
-
-    [GeneratedRegex("""<PageTitle>\s*([^@<][^<]*)</PageTitle>""")]
-    private static partial Regex TitleLiteralRegex();
-
-    [GeneratedRegex("""<meta name="description" content="@Loc\.T\("[^"]+",\s*"((?:[^"\\]|\\.)*)"\)"\s*/>""")]
-    private static partial Regex DescriptionLocRegex();
-
-    [GeneratedRegex("""<meta name="description" content="([^@][^"]*)"\s*/>""")]
-    private static partial Regex DescriptionLiteralRegex();
 }
 
 internal sealed record PageRoute(string Slug, string SourceRelPath, string[] ReadyLocales);
 
 internal sealed record SitemapUrl(string Loc, string LastMod);
+
+// path: the URL tools/Prerender should navigate the headless browser to.
+// outputRelPath: where under wwwroot to write the captured, Blazor-stripped
+// HTML -- both wwwroot-relative, forward-slash separated.
+internal sealed record PrerenderRoute(string Path, string OutputRelPath);
 
 // HreflangLinks: (hreflang, href) pairs shared identically across every url in
 // the group, self-reference and x-default included -- same shape sitemap.xml

--- a/tools/StaticSiteMeta/StaticSiteMeta.csproj
+++ b/tools/StaticSiteMeta/StaticSiteMeta.csproj
@@ -1,25 +1,33 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <!--
-    Build-time generator for issue #69: wwwroot/sitemap.xml was hand-maintained
-    (drifting from the real route table) and every page shared the same
-    site-wide og:title/description/twitter tags from wwwroot/index.html, so a
-    WhatsApp/social share of any two pages previewed identically.
+    Build-time generator, originally for issue #69: wwwroot/sitemap.xml was
+    hand-maintained (drifting from the real route table) and every page
+    shared the same site-wide og:title/description/twitter tags from
+    wwwroot/index.html, so a WhatsApp/social share of any two pages previewed
+    identically.
 
-    This tool runs after `dotnet publish`, before tools/StaticProductPages (issue
-    #65), so that tool's sitemap.xml merge lands on top of what this one writes
-    rather than the other way around. It:
-      - regenerates sitemap.xml from a declarative route table, with each url's
-        <lastmod> sourced from that page's own last git commit (no <priority>,
-        which Google ignores, matching the partial fix already shipped for #69);
-      - for each of those routes, clones the published index.html and swaps in
-        that page's own title/description into <title>, the description meta,
-        og:*, twitter:* and a <link rel="canonical"> (App.razor otherwise only
-        sets canonical after the WASM runtime boots, which is invisible to a
-        share-preview scraper).
+    This tool runs after `dotnet publish`, before tools/Prerender and
+    tools/StaticProductPages (issue #65), so those tools' sitemap.xml merges
+    land on top of what this one writes rather than the other way around. It:
+      - regenerates sitemap.xml from a declarative route table, with each
+        url's <lastmod> sourced from that page's own last git commit (no
+        <priority>, which Google ignores, matching the partial fix already
+        shipped for #69);
+      - emits routes.json (the routesOut command-line argument) listing every
+        marketing URL, plus its ready locale variants, for tools/Prerender
+        to crawl.
+
+    Until issue #63 landed, this tool ALSO cloned the published index.html
+    per route and swapped in that page's own title/description/canonical, a
+    regex-based approximation of what the real Razor components would
+    render. tools/Prerender now captures the real, fully-rendered page
+    (title, description, canonical, JSON-LD, body content) instead, which is
+    strictly more accurate, so that responsibility was removed here rather
+    than left to run and immediately be overwritten.
 
     Deliberately not part of Oxyniti.sln / Oxyniti.csproj, for the same reason
-    as tools/StaticProductPages: the workflow's `dotnet build`/`dotnet publish`
+    as its sibling tools: the workflow's `dotnet build`/`dotnet publish`
     (no explicit project) resolve to the one app project today, and folding a
     second publishable project into that would split publish output between
     two folders.

--- a/wwwroot/js/marketingIslands.js
+++ b/wwwroot/js/marketingIslands.js
@@ -1,0 +1,412 @@
+// Issue #63: the marketing routes (home, about, technology,
+// aquaculture-oxygenation, ras-oxygenation, products, faqs, contact,
+// privacy, terms, sitemap) are prerendered at build time
+// (tools/Prerender) and shipped WITHOUT the Blazor WASM runtime -- see that
+// tool's own comment for why. Everything on those pages that used to be a
+// Blazor @onclick/@oninput/@bind handler is wired here instead, in plain JS,
+// against the exact same DOM the Razor components already render (ids/names
+// added alongside this file for the handful of elements that needed a
+// stable hook -- see FreeDemoSection.razor, ProfitCalculatorSection.razor,
+// Layout/MainLayout.razor).
+//
+// Everything below is either a direct call into a JS module the app
+// *already* ships (scrollHelper.js, tankBubbles.js, testimonialTranslate.js,
+// mapLoader.js/mapHelper.js, qrLoader.js/qrHelper.js, droneStage.js,
+// lazyBackgroundVideo.js -- none of them have ever depended on a live
+// Blazor circuit, only on JS interop calling into them) or a small,
+// deliberately-scoped port of a Razor @code block's own logic (the profit
+// calculator's arithmetic, the free-demo form's localStorage write). Nothing
+// here talks to the not-yet-deployed Oxyniti backend
+// (Services/DemoAccountService.cs) -- every call it would make already
+// no-ops today (OxynitiApi:BaseAddress is unset in appsettings.json), so
+// this island reproduces today's actual fallback behaviour rather than a
+// call that would never succeed anyway. If that backend ships, this file
+// needs a matching fetch() added -- it will NOT pick that up automatically.
+//
+// App routes (/cart, /account, /checkout, /login, /product/{slug}, etc.)
+// still boot the real Blazor app and never load this file.
+(function () {
+    "use strict";
+
+    if (document.readyState === "loading") {
+        document.addEventListener("DOMContentLoaded", init);
+    } else {
+        init();
+    }
+
+    function init() {
+        initLanguageSelect();
+        initNavScrollSpy();
+        initProfitCalcScrollButtons();
+        initScrollToQueryParam();
+        initTankBubbles();
+        initTestimonialHoverTranslate();
+        initWhatsAppQrCodes();
+        initProfitCalculator();
+        initFreeDemoForm();
+        initVideos();
+        initOxyNanoClickToPlay();
+    }
+
+    // ---- Language switcher -------------------------------------------------
+    // Mirrors Services/LocalizedRoutes.cs -- keep in sync (also duplicated,
+    // with the same rationale, in tools/StaticSiteMeta/Program.cs).
+    var READY_LOCALES = {
+        about: ["ta", "te", "kn", "ml", "hi", "bn"],
+        contact: ["ta", "te", "kn", "ml", "hi", "bn"],
+    };
+
+    function currentSlug() {
+        var path = location.pathname.replace(/^\/+|\/+$/g, "");
+        var segments = path.length ? path.split("/") : [];
+        var locales = ["ta", "te", "kn", "ml", "hi", "bn"];
+        if (segments.length && locales.indexOf(segments[0]) !== -1) {
+            segments = segments.slice(1);
+        }
+        return segments.join("/");
+    }
+
+    // Mirrors LocalizationService.BuildLocalizedPath.
+    function buildLocalizedPath(slug, code) {
+        if (code === "en") return "/" + slug;
+        return "/" + code + (slug.length === 0 ? "" : "/" + slug);
+    }
+
+    function initLanguageSelect() {
+        var select = document.getElementById("language-select");
+        if (!select) return;
+
+        var slug = currentSlug();
+
+        select.addEventListener("change", function () {
+            var code = select.value;
+            if (!code) return;
+
+            var ready = code === "en" || (READY_LOCALES[slug] || []).indexOf(code) !== -1;
+            if (ready) {
+                location.href = buildLocalizedPath(slug, code);
+                return;
+            }
+
+            // No prerendered page exists for this locale+slug combination yet
+            // (Services/LocalizedRoutes.cs isn't "ready" for it either) --
+            // same outcome the live Blazor app gives today: stay on the
+            // English page rather than send the visitor to a 404.
+            select.value = "en";
+        });
+    }
+
+    // ---- Nav scroll-spy + same-page section links --------------------------
+    function initNavScrollSpy() {
+        if (typeof window.oxynitiScroll === "undefined") return;
+
+        if (document.querySelectorAll(".nav-link[data-section]").length) {
+            window.oxynitiScroll.initScrollSpy();
+        }
+
+        document.querySelectorAll(".nav-link[data-section]").forEach(function (a) {
+            a.addEventListener("click", function (e) {
+                var isHome = location.pathname === "/" || location.pathname === "";
+                var section = a.getAttribute("data-section");
+
+                if (isHome) {
+                    e.preventDefault();
+                    window.oxynitiScroll.setUrlQuietly("/?scrollTo=" + section);
+                    window.oxynitiScroll.toId(section);
+                }
+                // Not on the homepage: leave the real href ("/#section") alone
+                // -- a normal navigation to "/" then a native anchor jump,
+                // same end result without needing JS at all.
+            });
+        });
+    }
+
+    function initScrollToQueryParam() {
+        if (typeof window.oxynitiScroll === "undefined") return;
+
+        var params = new URLSearchParams(location.search);
+        var target = params.get("scrollTo");
+        if (target) {
+            setTimeout(function () {
+                window.oxynitiScroll.toId(target);
+            }, 150);
+        }
+    }
+
+    // ---- Profit-calculator scroll buttons (header + floating) --------------
+    function initProfitCalcScrollButtons() {
+        var buttons = document.querySelectorAll(".profit-btn, .floating-btn-profit");
+        if (!buttons.length) return;
+
+        buttons.forEach(function (btn) {
+            btn.addEventListener("click", function (e) {
+                var isHome = location.pathname === "/" || location.pathname === "";
+                if (isHome && typeof window.oxynitiScroll !== "undefined") {
+                    e.preventDefault();
+                    window.oxynitiScroll.toId("profit-calculator");
+                } else if (!document.getElementById("profit-calculator")) {
+                    // Only relevant off the homepage, where the calculator
+                    // doesn't exist on the page at all yet.
+                    e.preventDefault();
+                    location.href = "/?scrollTo=profit-calculator";
+                }
+            });
+        });
+    }
+
+    // ---- Tank bubble decoration (Technology section) ------------------------
+    function initTankBubbles() {
+        if (document.querySelector(".tank.regular .tank-bubble-layer") && window.oxynitiTankBubbles) {
+            window.oxynitiTankBubbles.start();
+        }
+    }
+
+    // ---- Testimonial hover-translate ----------------------------------------
+    function initTestimonialHoverTranslate() {
+        if (document.querySelector(".testimonials-section") && window.testimonialHoverTranslate) {
+            window.testimonialHoverTranslate.init(".testimonials-section");
+        }
+    }
+
+    // ---- WhatsApp group QR code(s) -------------------------------------------
+    function initWhatsAppQrCodes() {
+        var elements = document.querySelectorAll(".wa-group-qr-code[id]");
+        if (!elements.length) return;
+
+        import("./qrLoader.js").then(function (qrLoader) {
+            elements.forEach(function (el) {
+                qrLoader.whenVisible(el.id).then(function () {
+                    return qrLoader.ensureLoaded();
+                }).then(function () {
+                    // Matches SiteContact.WhatsAppGroupLink (C#) -- kept in
+                    // sync by hand, same as everything else this file ports.
+                    window.oxynitiQr.render(el.id, "https://chat.whatsapp.com/IlHfPXCNWk3LQa1LYPqceu?s=sw&p=i&mlu=4");
+                }).catch(function (err) {
+                    console.error("[marketingIslands] Error loading WhatsApp QR code:", err);
+                });
+            });
+        });
+    }
+
+    // ---- Profit calculator (ports ProfitCalculatorSection.razor's @code) ----
+    function initProfitCalculator() {
+        var acresInput = document.getElementById("calc-acres");
+        var priceInput = document.getElementById("calc-price");
+        if (!acresInput || !priceInput) return;
+
+        var acresLabel = document.getElementById("calc-acres-label");
+        var priceLabel = document.getElementById("calc-price-label");
+        var kgOut = document.getElementById("calc-kg");
+        var revenueOut = document.getElementById("calc-revenue");
+
+        var BASE_YIELD_KG_PER_ACRE = 2500;
+        var UPLIFT_LOW = 0.20;
+        var UPLIFT_HIGH = 0.30;
+
+        function fmtInr(n) {
+            return "₹" + Math.round(n).toLocaleString("en-IN");
+        }
+
+        function render() {
+            var acres = parseFloat(acresInput.value);
+            var pricePerKg = parseInt(priceInput.value, 10);
+
+            var lowKg = acres * BASE_YIELD_KG_PER_ACRE * UPLIFT_LOW;
+            var highKg = acres * BASE_YIELD_KG_PER_ACRE * UPLIFT_HIGH;
+            var lowRevenue = lowKg * pricePerKg;
+            var highRevenue = highKg * pricePerKg;
+
+            if (acresLabel) {
+                var acreWord = acres === 1 ? "acre" : "acres";
+                acresLabel.textContent = trimTrailingZero(acres) + " " + acreWord;
+            }
+            if (priceLabel) {
+                priceLabel.textContent = fmtInr(pricePerKg) + "/kg";
+            }
+            if (kgOut) {
+                kgOut.textContent = "+" + Math.round(lowKg).toLocaleString("en-IN") + " – " + Math.round(highKg).toLocaleString("en-IN") + " kg / year";
+            }
+            if (revenueOut) {
+                revenueOut.textContent = fmtInr(lowRevenue) + " – " + fmtInr(highRevenue);
+            }
+        }
+
+        function trimTrailingZero(n) {
+            return n % 1 === 0 ? n.toFixed(0) : n.toFixed(1);
+        }
+
+        acresInput.addEventListener("input", render);
+        priceInput.addEventListener("input", render);
+    }
+
+    // ---- Free-demo form (ports FreeDemoSection.razor's @code) ---------------
+    function initFreeDemoForm() {
+        var form = document.getElementById("free-demo-form");
+        if (!form) return;
+
+        initDemoMapPicker(form);
+
+        form.addEventListener("submit", function (e) {
+            e.preventDefault();
+
+            var name = fieldValue(form, "name");
+            var phone = fieldValue(form, "phone");
+            var place = fieldValue(form, "place");
+
+            if (!name || !phone || !place) {
+                showFormStatus(form, "Please fill this mandatory field.");
+                return;
+            }
+
+            var location_ = readPickedMapLocation();
+
+            // Matches Services/DemoBooking.cs's shape exactly -- Pages/MyDemos.razor
+            // reads this same localStorage key back through Services/DemoService.cs.
+            var booking = {
+                Id: (crypto.randomUUID ? crypto.randomUUID() : String(Date.now())).replace(/-/g, ""),
+                Name: name,
+                Phone: phone,
+                Place: place,
+                Size: fieldValue(form, "size") || "½ – 1 acre",
+                Species: fieldValue(form, "species") || "Tilapia / GIFT",
+                Latitude: location_ ? location_[0] : null,
+                Longitude: location_ ? location_[1] : null,
+                CreatedAtUtc: new Date().toISOString(),
+            };
+
+            try {
+                var existingJson = window.localStorage.getItem("oxyniti_demos");
+                var existing = existingJson ? JSON.parse(existingJson) : [];
+                existing.push(booking);
+                window.localStorage.setItem("oxyniti_demos", JSON.stringify(existing));
+            } catch (err) {
+                console.error("[marketingIslands] Error saving demo booking:", err);
+            }
+
+            // Services/DemoAccountService.cs's own fallback message for an
+            // unconfigured OxynitiApi:BaseAddress -- which is this app's
+            // actual state today (see this file's header comment).
+            showFormStatus(form, "Demo request received! We'll contact you shortly.");
+            form.reset();
+        });
+    }
+
+    function fieldValue(form, name) {
+        var el = form.querySelector('[data-field="' + name + '"]');
+        return el ? el.value.trim() : "";
+    }
+
+    function showFormStatus(form, message) {
+        var status = form.querySelector(".form-status");
+        if (!status) {
+            status = document.createElement("p");
+            status.className = "form-status";
+            var note = form.querySelector('[data-field="note"]');
+            if (note) {
+                form.insertBefore(status, note);
+            } else {
+                form.appendChild(status);
+            }
+        }
+        status.textContent = message;
+    }
+
+    var _demoMapId = null;
+
+    function initDemoMapPicker(form) {
+        var mapEl = form.querySelector("[data-demo-map]");
+        if (!mapEl || !mapEl.id) return;
+        _demoMapId = mapEl.id;
+
+        import("./mapLoader.js").then(function (mapLoader) {
+            return mapLoader.whenVisible(mapEl.id).then(function () {
+                return mapLoader.ensureLoaded();
+            });
+        }).then(function () {
+            window.oxynitiMap.initPicker(mapEl.id, null, null);
+        }).catch(function (err) {
+            console.error("[marketingIslands] Error loading the demo location map:", err);
+        });
+    }
+
+    function readPickedMapLocation() {
+        if (!_demoMapId || !window.oxynitiMap) return null;
+        try {
+            return window.oxynitiMap.getPickerLocation(_demoMapId);
+        } catch (err) {
+            console.error("[marketingIslands] Error reading picked map location:", err);
+            return null;
+        }
+    }
+
+    // ---- Lazy background video attach ----------------------------------------
+    // Dispatches on data-video-init, set alongside this file on each
+    // component's <video> tag: "lazy-eager" (Hero -- attaches immediately),
+    // "lazy" (below-the-fold background loops), "drone-stage" (the sky-view
+    // canvas-backdrop treatment, its own module).
+    function initVideos() {
+        var droneVideo = document.querySelector('[data-video-init="drone-stage"]');
+        if (droneVideo) {
+            var canvas = droneVideo.closest(".drone-stage");
+            canvas = canvas ? canvas.querySelector(".drone-stage-backdrop") : null;
+            import("./droneStage.js").then(function (droneStage) {
+                droneStage.init(droneVideo, canvas);
+            }).catch(function (err) {
+                console.error("[marketingIslands] Error starting drone stage video:", err);
+            });
+        }
+
+        var lazyVideos = document.querySelectorAll(
+            '[data-video-init="lazy-eager"], [data-video-init="lazy"]'
+        );
+        if (!lazyVideos.length) return;
+
+        import("./lazyBackgroundVideo.js").then(function (lazyBackgroundVideo) {
+            lazyVideos.forEach(function (video) {
+                var eager = video.getAttribute("data-video-init") === "lazy-eager";
+                var poster = eager ? video.parentElement.querySelector("img.hero-poster") : null;
+                lazyBackgroundVideo.init(video, poster, {
+                    eager: eager,
+                    respectNarrowViewport: !eager,
+                    deferUntilPosterPaint: eager,
+                });
+            });
+        }).catch(function (err) {
+            console.error("[marketingIslands] Error attaching background video(s):", err);
+        });
+    }
+
+    // ---- OXY-Nano Series click-to-play ---------------------------------------
+    function initOxyNanoClickToPlay() {
+        var button = document.querySelector(".oxy-video-play");
+        if (!button) return;
+
+        button.addEventListener("click", function () {
+            var frame = button.closest(".oxy-video-frame");
+            if (!frame) return;
+
+            var video = document.createElement("video");
+            video.controls = true;
+            video.autoplay = true;
+            video.playsInline = true;
+            video.preload = "auto";
+            video.poster = "/images/oxy-nano-poster.webp";
+            video.setAttribute("aria-label", button.getAttribute("aria-label") || "OXY-Nano Series product video");
+
+            var source = document.createElement("source");
+            // The Tamil variant (Services/LocalizationService) only ever
+            // applies on a locale-prefixed page; the homepage isn't
+            // prerendered per-locale (see tools/StaticSiteMeta's route
+            // table), so this island only ever needs the English source.
+            source.src = "/videos/oxy-nano-series.mp4";
+            source.type = "video/mp4";
+            video.appendChild(source);
+            video.appendChild(document.createTextNode("Your browser does not support the video tag."));
+
+            frame.replaceChild(video, button);
+            video.play().catch(function () {
+                // Autoplay may be blocked; controls are already visible.
+            });
+        });
+    }
+})();

--- a/wwwroot/staticwebapp.config.json
+++ b/wwwroot/staticwebapp.config.json
@@ -1,6 +1,6 @@
 {
   "navigationFallback": {
-    "rewrite": "/index.html",
+    "rewrite": "/app-shell.html",
     "exclude": [
       "/favicon.ico",
       "/robots.txt",
@@ -56,6 +56,7 @@
     { "route": "/robots.txt", "headers": { "Cache-Control": "public, max-age=3600" } },
     { "route": "/sitemap.xml", "headers": { "Cache-Control": "public, max-age=3600" } },
     { "route": "/llms.txt", "headers": { "Cache-Control": "public, max-age=3600" } },
-    { "route": "/index.html", "headers": { "Cache-Control": "public, max-age=0, must-revalidate" } }
+    { "route": "/index.html", "headers": { "Cache-Control": "public, max-age=0, must-revalidate" } },
+    { "route": "/app-shell.html", "headers": { "Cache-Control": "public, max-age=0, must-revalidate" } }
   ]
 }


### PR DESCRIPTION
## Summary

Closes #63. Every marketing route (`/`, `/about`, `/technology`, `/aquaculture-oxygenation`, `/ras-oxygenation`, `/products`, `/faqs`, `/contact`, `/privacy`, `/terms`, `/sitemap`) shipped nothing but the pre-boot shell until the 2.7 MB Blazor WASM runtime downloaded and booted — the LCP ceiling (#46), the reason nothing but the homepage hero existed in raw HTML for a crawler, and the reason AI answer engines had no text to cite.

Implements the issue's own recommended route (a): prerender in CI, one codebase, `blazor.webassembly.js` loaded only on app routes.

## What's here

- **`tools/Prerender`** (new): a build-time headless-Chromium (`Microsoft.Playwright`) crawler. Boots the *real* app for each marketing route against a local server serving the published `wwwroot`, waits for it to settle, captures the fully-rendered DOM — title, description, canonical, JSON-LD, body content, all produced by the real Razor components, not a regex approximation — and strips the `blazor.webassembly.js` loader out before writing the page to disk.
- **`wwwroot/js/marketingIslands.js`** (new): wires everything on those pages that used to be a Blazor event handler — the profit calculator, the free-demo form (incl. its Leaflet map picker), the language switcher, nav scroll-spy, tank-bubble/testimonial/QR/video decoration — to the *same* plain-JS modules the app already shipped for them (`scrollHelper.js`, `tankBubbles.js`, `mapLoader.js`, `qrLoader.js`, `droneStage.js`, `lazyBackgroundVideo.js`, `testimonialTranslate.js` — none of them ever depended on a live Blazor circuit). Nothing here calls the not-yet-deployed Oxyniti backend (`DemoAccountService`) — every call it makes already no-ops today, so this reproduces today's actual fallback behaviour rather than a call that would never succeed anyway.
- Small `id`/`name`/`data-*` additions to `FreeDemoSection.razor`, `ProfitCalculatorSection.razor`, `MainLayout.razor`, and three video components (`Hero`, `SkyViewSection`, `FieldFootageSection`) give that script stable hooks — Blazor doesn't render a `name` attribute for `@bind-Value` inputs, so without these there'd be no reliable way to tell fields apart in plain JS.
- **`staticwebapp.config.json`**: `navigationFallback` now rewrites unmatched routes to a new `app-shell.html` (a preserved copy of the original WASM-booting `index.html`) instead of `index.html` itself, since `index.html` is now the crawlable homepage. Every app route (`/cart`, `/account`, `/checkout`, `/login`, `/product/{slug}`, `/products/{type}/{slug}`, `/search`, etc.) still boots Blazor exactly as before — untouched by this change.
- **`tools/StaticSiteMeta`**: trimmed to sitemap.xml generation (still git-lastmod-sourced) plus emitting the route list `tools/Prerender` crawls. Its old per-route `index.html` head-swap is superseded by real captured content, so it's removed rather than left to run and be immediately overwritten.
- CI (`azure-static-web-apps-deploy.yml`): installs Playwright's Chromium, runs the prerender step between `tools/StaticSiteMeta` and `tools/StaticProductPages` (product pages are untouched — they keep the WASM loader, since MakerClient/auth/Stripe/cart still need it per the issue's own scope).

## Two bugs prerendering surfaced (fixed here, not filed separately)

Regex-swapping a static template had been accidentally masking both of these:

1. `App.razor`'s self-referencing `<link rel="canonical">` (a `<HeadContent>` inside the Router's `<Found>` template) doesn't survive to the final DOM on any route whose page also runs the locale-resolution `OnParametersSetAsync` logic — only the three plain pages without it (Privacy/Terms/Sitemap) kept their canonical. Looks like a genuine Blazor `HeadOutlet` ordering bug; root-causing WASM head-rendering internals felt out of scope for this PR, so `tools/Prerender` now asserts the canonical directly (it already knows the right URL for every route it's asked to capture).
2. `<meta name="description">` was duplicated: the site-wide default baked into `index.html` is never removed, and each page's own `<HeadContent>` description is simply appended after it by `HeadOutlet` — two tags, in the *wrong* precedence order for a crawler (first tag wins by convention). `og:title`/`og:description`/`twitter:title`/`twitter:description` also never updated at all, since nothing in the app sets them via `HeadContent`. `tools/Prerender` dedupes the description (keeps the specific one) and derives the OG/Twitter tags from the real captured title/description.

## Known trade-off

A signed-in visitor landing directly on a marketing page now always sees the "Login" icon in the header rather than their account menu, since the prerendered snapshot always reflects the logged-out state. Clicking through to any app route still authenticates normally once Blazor boots there. This follows directly from the issue's own MakerClient/auth boundary and felt like the right call rather than reintroducing WASM to the marketing surface for this one case — flagging it here in case it should be tracked separately.

## Test plan

Verified locally end-to-end (`dotnet publish` → `tools/StaticSiteMeta` → `tools/Prerender` against the real app), then a headless-browser smoke test of the final output:
- [x] Zero `_framework/*.wasm` requests on the homepage
- [x] Distinct `<title>`/description/canonical/OG/Twitter per route, including locale variants (`/ta/about`, `/kn/contact`, etc.)
- [x] All 5 JSON-LD blocks present on the homepage (Organization/LocalBusiness, FAQPage, 3× VideoObject)
- [x] Profit calculator slider reacts and updates the estimate
- [x] Free-demo form submits, writes a `Services/DemoBooking.cs`-shaped entry to `localStorage['oxyniti_demos']`, shows the same fallback status message the live app shows today
- [x] Nav scroll-spy link click prevents a real navigation and smooth-scrolls to the target section
- [x] Zero browser console errors
- [x] `dotnet build` clean on `Oxyniti.csproj`, `tools/StaticSiteMeta`, `tools/Prerender`
- [ ] Full CI run (Playwright browser install + the actual GitHub Actions environment) — not something I could exercise locally beyond a Windows-PowerShell dry run of the same `playwright.ps1 install` command
- [ ] Real Lighthouse/WebPageTest LCP measurement on a deployed preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)