### PR TITLE
fix(auth): stop refresh from bouncing logged-in users to /login

### DIFF
--- a/Layout/MainLayout.razor
+++ b/Layout/MainLayout.razor
@@ -6,6 +6,7 @@
 @inject IJSRuntime JSRuntime
 @inject IMakerClient MakerClient
 @inject LocalizationService Loc
+@inject AuthReadyGate AuthReady
 
 <div class="page">
 
@@ -263,6 +264,13 @@
         {
             Console.WriteLine(
                 $"[MainLayout] Error initializing authentication: {ex}");
+        }
+        finally
+        {
+            // Unblock any guarded page awaiting AuthReady.Ready even if
+            // rehydration threw -- IsAuthenticated is safe to read once this
+            // fires, whether that resolves to true or false.
+            AuthReady.SignalReady();
         }
 
 

--- a/Pages/Account.razor
+++ b/Pages/Account.razor
@@ -7,6 +7,7 @@
 @inject CartService CartService
 @inject NavigationManager Nav
 @inject LocalizationService Loc
+@inject AuthReadyGate AuthReady
 
 <PageTitle>Your Account - Oxyniti</PageTitle>
 
@@ -157,6 +158,13 @@ else
     protected override async Task OnInitializedAsync()
     {
         Loc.OnChange += StateHasChanged;
+
+        // Wait for MainLayout's token rehydration from localStorage before
+        // trusting IsAuthenticated -- on a hard refresh this page's
+        // OnInitializedAsync can otherwise run first and see the
+        // freshly-constructed "false" default, bouncing a signed-in user to
+        // /login.
+        await AuthReady.Ready;
 
         if (!AuthenticationService.IsAuthenticated)
         {

--- a/Pages/Cart.razor
+++ b/Pages/Cart.razor
@@ -3,6 +3,7 @@
 @inject NavigationManager Nav
 @inject IAuthenticationService AuthenticationService
 @inject LocalizationService Loc
+@inject AuthReadyGate AuthReady
 
 <div class="container-fluid px-4 py-5">
     <h2 class="mb-4">@Loc.T("cart.title", "Your Cart")</h2>
@@ -114,8 +115,13 @@
             ? text
             : text.Substring(0, maxChars) + "...";
     }
-    private void HandleCheckout()
+    private async Task HandleCheckout()
     {
+        // Same rehydration race as Account.razor: guard against reading
+        // IsAuthenticated before MainLayout's token restore from
+        // localStorage has finished.
+        await AuthReady.Ready;
+
         if (!AuthenticationService.IsAuthenticated)
         {
             Nav.NavigateTo("/login");

--- a/Program.cs
+++ b/Program.cs
@@ -16,6 +16,7 @@ builder.RootComponents.Add<HeadOutlet>("head::after");
 
 builder.Services.AddSingleton(sp => new HttpClient { BaseAddress = new Uri(builder.HostEnvironment.BaseAddress) });
 builder.Services.AddSingleton<CartService>();
+builder.Services.AddSingleton<AuthReadyGate>();
 builder.Services.AddSingleton<DemoService>();
 builder.Services.AddSingleton<BusinessInfoService>();
 builder.Services.AddSingleton<LocalizationService>();

--- a/Services/AuthReadyGate.cs
+++ b/Services/AuthReadyGate.cs
@@ -1,0 +1,18 @@
+namespace Oxyniti.Services;
+
+// MainLayout kicks off AuthenticationService.InitializeAsync() (rehydrates the
+// token from localStorage) on every app boot, but a routed page's own
+// OnInitializedAsync starts around the same tick -- before that rehydration
+// finishes -- so a page that reads AuthenticationService.IsAuthenticated on
+// load can see the freshly-constructed "false" default and redirect to
+// /login on a hard refresh, even though a valid token is sitting in storage.
+// Pages that guard on auth state should await Ready first.
+public class AuthReadyGate
+{
+    private readonly TaskCompletionSource _tcs =
+        new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+    public Task Ready => _tcs.Task;
+
+    public void SignalReady() => _tcs.TrySetResult();
+}


### PR DESCRIPTION
## Summary
- Fixes a bug where a hard refresh on `/account` (or clicking checkout on `/cart` right after a refresh) logs a signed-in user out.
- Root cause: `MainLayout` rehydrates the auth token from localStorage via `AuthenticationService.InitializeAsync()`, but `Account.razor`'s `OnInitializedAsync` (and `Cart.razor`'s checkout guard) read `IsAuthenticated` at nearly the same tick — before that rehydration finishes — and see the freshly-constructed "not logged in" default, redirecting to `/login` even though a valid token is in storage.
- Fix: added `AuthReadyGate`, a small singleton `MainLayout` signals once `InitializeAsync()` completes (success or failure). Guarded pages now `await AuthReady.Ready` before trusting `IsAuthenticated`, instead of racing the rehydration.

## Test plan
- [x] `dotnet build` succeeds with 0 warnings/errors
- [ ] Manual: log in, hard-refresh on `/account` — stays logged in instead of bouncing to `/login`
- [ ] Manual: log in, hard-refresh on `/cart`, click checkout immediately — goes to `/checkout`, not `/login`

🤖 Generated with [Claude Code](https://claude.com/claude-code)