### PR TITLE
fix(marketing): show account icon instead of Login when already signed in

### DIFF
--- a/wwwroot/js/marketingIslands.js
+++ b/wwwroot/js/marketingIslands.js
@@ -35,6 +35,7 @@
     }
 
     function init() {
+        initAuthHeader();
         initLanguageSelect();
         initNavScrollSpy();
         initProfitCalcScrollButtons();
@@ -46,6 +47,57 @@
         initFreeDemoForm();
         initVideos();
         initOxyNanoClickToPlay();
+    }
+
+    // ---- Header login/account icon -----------------------------------------
+    // This prerendered shell has no live Blazor circuit, so the header always
+    // ships as logged-out (Layout/MainLayout.razor's IsAuthenticated check
+    // never runs here). If a real session token is already sitting in
+    // localStorage (maker_access_token -- Maker.RampEdge's AuthenticationService,
+    // same key it reads on every app boot), swap the login icon for an
+    // account one so a signed-in visitor landing here after login, or after
+    // a refresh, doesn't see a "logged out" header. Only cosmetic: it
+    // doesn't touch storage or auth state, just re-points the link at
+    // /account -- a real Blazor route that verifies the session itself.
+    function initAuthHeader() {
+        var link = document.querySelector(".header-actions .login-avatar");
+        if (!link) return;
+
+        var token = safeGetItem("maker_access_token");
+        if (!token) return;
+
+        var claims = decodeJwtPayload(token);
+        if (!claims || (claims.exp && claims.exp * 1000 <= Date.now())) return;
+
+        // Mirrors MainLayout.razor's UserInitial.
+        var email = claims.email;
+        var initial = email && email.length ? email.charAt(0).toUpperCase() : "O";
+
+        link.href = "/account";
+        link.className = "user-avatar";
+        link.title = email || "Account";
+        link.setAttribute("aria-label", "Account");
+        link.textContent = initial;
+    }
+
+    function safeGetItem(key) {
+        try {
+            return window.localStorage.getItem(key);
+        } catch (err) {
+            return null;
+        }
+    }
+
+    function decodeJwtPayload(token) {
+        try {
+            var parts = token.split(".");
+            if (parts.length < 2) return null;
+            var b64 = parts[1].replace(/-/g, "+").replace(/_/g, "/");
+            while (b64.length % 4) b64 += "=";
+            return JSON.parse(atob(b64));
+        } catch (err) {
+            return null;
+        }
     }
 
     // ---- Language switcher -------------------------------------------------


### PR DESCRIPTION
## Summary
Companion fix to #96. That PR stopped `/account` and `/cart` from bouncing a signed-in user to `/login` on refresh (a race in Blazor's own auth rehydration). But the bug report's actual repro screenshot was the **homepage**, and that's a different root cause: issue #63 moved marketing pages (home, products, technology, etc.) to prerendered static HTML with **no Blazor WASM runtime at all**. The header's login/account icon is baked into that static markup server-side, so it can never reflect the real client session — a signed-in visitor lands on `/` right after logging in (Login.razor redirects there) or refreshes it, and always sees the "Login" icon, which reads as having been signed out, even though `maker_access_token` is still sitting in localStorage the whole time.

- Adds `initAuthHeader()` to `wwwroot/js/marketingIslands.js` — the file issue #63 already established as the place to port small bits of Blazor behavior to plain JS for these static pages.
- If a live, unexpired session token is in `localStorage` (`maker_access_token`, the same key `Maker.RampEdge.AuthenticationService` already reads on every app boot), swap the login icon for an account icon pointing at `/account` — a real Blazor route that independently verifies the session.
- Purely cosmetic: doesn't touch storage or auth state, just the icon.

## Test plan
- [x] Verified against the **actual live production `index.html`** (fetched from oxyniti.com) served locally with the updated JS: header shows the login icon with no token in storage, and swaps to the account icon (with the correct initial) after seeding a token and hard-refreshing — no console errors from the new code.
- [ ] Manual: log in for real, confirm the homepage header shows the account icon instead of Login after the post-login redirect and after a manual refresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)