### PR TITLE
fix(prerender): stop one route's saved language leaking into the next

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,10 @@
 /tools/StaticProductPages/obj
 /tools/StaticSiteMeta/bin
 /tools/StaticSiteMeta/obj
+/tools/Prerender/bin
+/tools/Prerender/obj
+# tools/StaticSiteMeta's --routes-out (issue #63); regenerated on every build.
+/bin/Release/prerender-routes.json
 # Blue Sharc: .sharc/ is a mix of machine-local runtime caches (cracked
 # substrate .rac files, peer/provider configs with this machine's absolute
 # install path, session logs) and derived files (state.json/tree.json/

--- a/Layout/MainLayout.razor
+++ b/Layout/MainLayout.razor
@@ -61,9 +61,16 @@
                         @onchange="OnLanguageChanged"
                         aria-label="@Loc.T("nav.langSelect", "Website language")">
 
+                    @* selected="" as well as the select's own value=: the
+                       marketing routes ship as prerendered HTML with no Blazor
+                       runtime (tools/Prerender), and a <select>'s value is a DOM
+                       property that doesn't survive serialization -- without the
+                       attribute, a captured /bn/about renders Bengali under a
+                       picker reading "English". *@
                     @foreach (var lang in LocalizationService.Languages)
                     {
-                        <option value="@lang.Code">
+                        <option value="@lang.Code"
+                                selected="@(lang.Code == Loc.CurrentLanguage)">
                             @lang.Native
                         </option>
                     }

--- a/tools/Prerender/Program.cs
+++ b/tools/Prerender/Program.cs
@@ -82,7 +82,6 @@ internal static partial class Program
 
         using var playwright = await Playwright.CreateAsync();
         await using var browser = await playwright.Chromium.LaunchAsync(new BrowserTypeLaunchOptions { Headless = true });
-        var page = await browser.NewPageAsync();
 
         var failures = new List<string>();
 
@@ -90,7 +89,7 @@ internal static partial class Program
         {
             try
             {
-                var html = await CaptureAsync(page, server.BaseAddress, route.Path);
+                var html = await CaptureAsync(browser, server.BaseAddress, route.Path);
                 var outputPath = Path.Combine(wwwroot, route.OutputRelPath.Replace('/', Path.DirectorySeparatorChar));
                 Directory.CreateDirectory(Path.GetDirectoryName(outputPath)!);
                 WriteHtmlFile(outputPath, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false).GetBytes(html));
@@ -142,9 +141,28 @@ internal static partial class Program
     // Boots the real Blazor app for this route (WASM and all -- the only way
     // to get output that's actually faithful to what the Razor components
     // render, JSON-LD/title/meta included) and captures the settled DOM.
-    private static async Task<string> CaptureAsync(IPage page, string baseAddress, string routePath)
+    private static async Task<string> CaptureAsync(IBrowser browser, string baseAddress, string routePath)
     {
         var url = baseAddress.TrimEnd('/') + routePath;
+
+        // One throwaway browser context -- i.e. one empty localStorage -- per
+        // route, because that is the only visitor these files are ever
+        // rendered for: someone arriving cold at this exact URL.
+        //
+        // The app persists the language picker's choice in localStorage
+        // ("oxyniti-lang"), and LocalizationService.InitializeAsync reads it
+        // back on any *unprefixed* URL: it repaints the page in the saved
+        // language, or -- when LocalizedRoutes says a translated twin is
+        // ready -- redirects to it outright. Sharing one page across every
+        // capture therefore let each locale route poison the ones after it:
+        // /bn/about (the last locale of the first localized slug) left "bn"
+        // in localStorage, so /technology, /aquaculture-oxygenation,
+        // /ras-oxygenation, /products and /faqs were all captured with
+        // Bengali chrome, and /contact was captured as /bn/contact outright
+        // -- English URLs shipping Bengali HTML, which is what a visitor
+        // clicking "Products" from the English homepage actually saw.
+        await using var context = await browser.NewContextAsync();
+        var page = await context.NewPageAsync();
 
         try
         {
@@ -170,9 +188,62 @@ internal static partial class Program
         // fixed settle cost here is the right trade against flakiness.
         await page.WaitForTimeoutAsync(500);
 
+        // Belt-and-braces on the isolation above: a capture that ends up on a
+        // different path than it asked for has rendered someone else's page
+        // into this route's file -- wrong body copy, wrong <html lang>, and a
+        // canonical/hreflang set NormalizeHeadMeta will then happily stamp
+        // with this route's URL. Fail the build instead of shipping it.
+        var landed = new Uri(page.Url).AbsolutePath.TrimEnd('/');
+        var expected = new Uri(url).AbsolutePath.TrimEnd('/');
+        if (!string.Equals(landed, expected, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException(
+                $"Capturing '{routePath}' ended up at '{page.Url}' -- refusing to write that page's DOM to this route's file.");
+        }
+
+        // A locale route's body copy arrives as its own fetch
+        // (wwwroot/i18n/{code}.json), and the page only re-renders -- and
+        // only then sets <html lang> -- once it lands. NetworkIdle normally
+        // covers that, but the timeout fallback above does not, and a
+        // capture that settles first writes an ENGLISH body to a Tamil URL:
+        // precisely the hreflang mismatch LocalizedRoutes exists to prevent
+        // (issue #67). Observed flaking one or two locale routes per run
+        // against a cold BusinessInfo API, so wait for the translation to
+        // actually be on the document rather than trusting the settle delay.
+        var expectedLocale = LocaleOf(routePath);
+        if (expectedLocale is not null)
+        {
+            try
+            {
+                await page.WaitForFunctionAsync(
+                    "code => document.documentElement.lang === code",
+                    expectedLocale,
+                    new PageWaitForFunctionOptions { Timeout = 15_000 });
+            }
+            catch (TimeoutException)
+            {
+                var actual = await page.EvaluateAsync<string>("() => document.documentElement.lang");
+                throw new InvalidOperationException(
+                    $"'{routePath}' never applied its '{expectedLocale}' translations (<html lang> was '{actual}') -- refusing to write an untranslated page to a locale URL.");
+            }
+        }
+
         var html = await page.ContentAsync();
         html = StripBlazorLoader(html, routePath);
         return NormalizeHeadMeta(html, routePath);
+    }
+
+    // Mirrors LocalizationService.Languages minus "en" -- the six codes that
+    // are legal URL prefixes. Duplicated here for the same reason
+    // tools/StaticSiteMeta duplicates the ready-locale map: this tool runs
+    // against the published output, not the app's own assemblies.
+    private static readonly string[] LocalePrefixes = ["ta", "kn", "te", "ml", "hi", "bn"];
+
+    /// <summary>The locale a "/ta/about"-shaped route must render in, or null for an unprefixed one.</summary>
+    private static string? LocaleOf(string routePath)
+    {
+        var first = routePath.Trim('/').Split('/')[0];
+        return Array.IndexOf(LocalePrefixes, first) >= 0 ? first : null;
     }
 
     private const string Origin = "https://www.oxyniti.com";


### PR DESCRIPTION
## The bug

Clicking **Products** in the top bar from the English homepage switches the site to Bengali. It's not the nav link — the prerendered page it lands on is already Bengali. Live right now:

| URL | ships as |
|---|---|
| `/products` | nav reads `পণ্য`, picker aria-label `ওয়েবসাইটের ভাষা` |
| `/faqs` | `<title>সাধারণ জিজ্ঞাসা - অক্সিনিটি</title>` |
| `/contact` | `<html lang="bn">`, fully Bengali |
| `/technology`, `/aquaculture-oxygenation`, `/ras-oxygenation` | Bengali chrome |

`/` and `/about` are fine, which is exactly the tell.

## Root cause

`tools/Prerender` captured all 23 routes through **one** Playwright page — so one `localStorage`. Every locale route calls `Loc.SetLanguageAsync(locale)`, which persists `oxyniti-lang`, and `LocalizationService.InitializeAsync` reads that key back on any *unprefixed* URL: it repaints in the saved language, or redirects outright to the translated twin when `LocalizedRoutes` says one is ready.

Routes are captured in slug order, so `/bn/about` (last locale of the first localized slug) poisoned everything after it:

```
/ , /about                      <- captured before any locale ran: clean
/ta/about … /bn/about           <- leaves "bn" in localStorage
/technology … /products, /faqs  <- repainted Bengali (in-place fallback)
/contact                        <- redirected to /bn/contact and captured there
```

## The fix

- **A throwaway `BrowserContext` per route** — one empty `localStorage`, i.e. the cold first-time visitor these files are the only thing ever rendered for.
- **Assert the capture ends on the path it asked for.** This is what silently turned `/contact` into `/bn/contact`; it now fails the build.
- **Assert a locale route applied its translations** before the DOM is taken. Verifying the fix surfaced a *second, pre-existing* race: the 20s NetworkIdle fallback (cold BusinessInfo API, #26) let one or two locale routes per run capture before `i18n/{code}.json` landed, writing ENGLISH body copy to a Tamil URL — the hreflang mismatch #67 exists to prevent. Waiting on `<html lang>` removes it.
- **`selected` on the picker's current option.** A `<select>`'s value is a DOM property that doesn't survive serialization, so every prerendered locale page shipped Bengali/Tamil content under a picker reading "English".
- `.gitignore`: `tools/Prerender/bin|obj` (the other two tools were already listed) and the generated `prerender-routes.json`.

## Verification

Two consecutive clean `dotnet publish` + full 23-route prerender runs, both green:

- 11 English routes: `<html lang="en">`, `Products` in the nav, `en` option selected
- 12 locale routes: matching `<html lang>` and matching option selected

Runs before the translation wait flaked `ml/about`, `hi/contact`, `bn/contact`; the last two runs are clean.

**The live site stays broken until this deploys** — the fix is in the build step, so it only takes effect on the next Azure SWA run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
