### PR TITLE
Stop prerendering /products; refuse captures that still show a skeleton

### DIFF
--- a/tools/Prerender/Program.cs
+++ b/tools/Prerender/Program.cs
@@ -228,6 +228,33 @@ internal static partial class Program
             }
         }
 
+        // A page that is still showing a loading state has not finished
+        // rendering, whatever the network-idle heuristic above concluded.
+        // Shipping it is worse than failing: StripBlazorLoader removes the
+        // only thing that could ever complete the render, so the skeleton
+        // becomes permanent for every visitor (this is how /products once
+        // shipped as six grey placeholder cards -- its product grid is a
+        // live API call that outran the 20 s network-idle budget on a cold
+        // backend). Refuse the capture; the fix is either to wait for that
+        // route's real content or, for a page that needs runtime data, to
+        // mark it Prerender: false in tools/StaticSiteMeta so it boots the
+        // app instead.
+        var stillLoading = await page.EvaluateAsync<string?>(
+            """
+            () => {
+                const sel = '.placeholder-wave, .placeholder, [aria-busy="true"], [role="status"]';
+                const hit = document.querySelector(sel);
+                if (!hit) return null;
+                return hit.className || hit.getAttribute('role') || hit.tagName;
+            }
+            """);
+        if (stillLoading is not null)
+        {
+            throw new InvalidOperationException(
+                $"'{routePath}' was still showing a loading state ('{stillLoading}') when captured -- refusing to freeze a skeleton into a static page. " +
+                "Either this route needs a longer/more specific ready wait, or it depends on runtime data and must be marked Prerender: false in tools/StaticSiteMeta.");
+        }
+
         var html = await page.ContentAsync();
         html = StripBlazorLoader(html, routePath);
         return NormalizeHeadMeta(html, routePath);

--- a/tools/StaticSiteMeta/Program.cs
+++ b/tools/StaticSiteMeta/Program.cs
@@ -29,7 +29,19 @@ internal static class Program
         new("technology", "Pages/Technology.razor", []),
         new("aquaculture-oxygenation", "Pages/AquacultureOxygenation.razor", []),
         new("ras-oxygenation", "Pages/RasOxygenation.razor", []),
-        new("products", "Pages/Products.razor", ["ta", "te", "kn", "ml", "hi", "bn"]),
+        // Listed in sitemap.xml but NOT prerendered: the product-type grid is a
+        // live MakerClient call (Pages/Components/DiscoverProductTypes.razor),
+        // and a capture that lands before that call returns freezes the
+        // loading skeleton into the static file forever -- the Blazor loader
+        // is stripped from every prerendered page, so nothing on the shipped
+        // page can ever finish the fetch. That is exactly what shipped once:
+        // /products showed six grey placeholder cards to every visitor. The
+        // route now falls through to app-shell.html and boots the real app.
+        // Rule: a route is prerenderable only when it renders completely
+        // with no runtime API call; tools/Prerender refuses a capture that
+        // still shows a skeleton, so re-adding this without a data-free
+        // render fails the build instead of the live site.
+        new("products", "Pages/Products.razor", ["ta", "te", "kn", "ml", "hi", "bn"], Prerender: false),
         new("faqs", "Pages/Faqs.razor", []),
         new("contact", "Pages/Contact.razor", ["ta", "te", "kn", "ml", "hi", "bn"]),
         new("privacy", "Pages/Privacy.razor", []),
@@ -66,7 +78,10 @@ internal static class Program
             var enLastMod = GitLastModifiedDate(repoRoot, route.SourceRelPath);
 
             var urls = new List<SitemapUrl> { new(enUrl, enLastMod) };
-            prerenderRoutes.Add(new PrerenderRoute(enPath, route.Slug.Length == 0 ? "index.html" : $"{route.Slug}/index.html"));
+            if (route.Prerender)
+            {
+                prerenderRoutes.Add(new PrerenderRoute(enPath, route.Slug.Length == 0 ? "index.html" : $"{route.Slug}/index.html"));
+            }
 
             foreach (var locale in route.ReadyLocales)
             {
@@ -74,9 +89,12 @@ internal static class Program
                 var localeLastMod = MaxDate(enLastMod, GitLastModifiedDate(repoRoot, localeJson));
                 urls.Add(new($"{Origin}/{locale}/{route.Slug}", localeLastMod));
 
-                var localePath = route.Slug.Length == 0 ? $"/{locale}" : $"/{locale}/{route.Slug}";
-                var localeOutput = route.Slug.Length == 0 ? $"{locale}/index.html" : $"{locale}/{route.Slug}/index.html";
-                prerenderRoutes.Add(new PrerenderRoute(localePath, localeOutput));
+                if (route.Prerender)
+                {
+                    var localePath = route.Slug.Length == 0 ? $"/{locale}" : $"/{locale}/{route.Slug}";
+                    var localeOutput = route.Slug.Length == 0 ? $"{locale}/index.html" : $"{locale}/{route.Slug}/index.html";
+                    prerenderRoutes.Add(new PrerenderRoute(localePath, localeOutput));
+                }
             }
 
             var group = new SitemapGroup(urls, route.ReadyLocales.Length > 0 ? [.. route.ReadyLocales] : []);
@@ -170,7 +188,10 @@ internal static class Program
     }
 }
 
-internal sealed record PageRoute(string Slug, string SourceRelPath, string[] ReadyLocales);
+// Prerender: false keeps the route (and its ready locales) in sitemap.xml but
+// leaves it to app-shell.html at request time -- for pages whose content is a
+// runtime API call and so cannot be captured faithfully at build time.
+internal sealed record PageRoute(string Slug, string SourceRelPath, string[] ReadyLocales, bool Prerender = true);
 
 internal sealed record SitemapUrl(string Loc, string LastMod);
 


### PR DESCRIPTION
## Problem

Clicking **Products** on www.oxyniti.com shows six grey placeholder cards that never load.

`/products` is prerendered at build time. Its product-type grid is a live `MakerClient.ProductGroupsAsync()` call, and on a cold `maker-rest-api` backend that call outran the prerenderer's 20 s network-idle budget. The fallback captured the loading skeleton, then `StripBlazorLoader` removed the Blazor loader from the page, so nothing on the shipped page could ever finish the fetch. The live HTML confirms it: it contains the "Loading product types…" status text and no `blazor.webassembly.js`.

Locally (with Blazor running) the page works and the product type appears once the API answers, after roughly 8 s.

## Fix

- **tools/StaticSiteMeta**: `PageRoute` gains a `Prerender` flag (default `true`). `products` is marked `Prerender: false`, so it and its six locale URLs stay in `sitemap.xml` but are no longer written to the prerender route list. The URL now falls through to `app-shell.html` and boots the real app with live data, like `/cart` and `/account` already do.
- **tools/Prerender**: after the settle wait, the capture is refused if the DOM still contains a Bootstrap placeholder skeleton, an `aria-busy` element, or a `role="status"` region. A page that depends on runtime data now fails the build with a message pointing at `Prerender: false`, instead of shipping a frozen skeleton.

## Verification (local, against a fresh `dotnet publish`)

- StaticSiteMeta: sitemap still lists all 7 Products URLs; prerender route list is 28 routes with no `products` entry.
- Prerender real run: all 28 routes captured, exit 0, no `placeholder-wave` / "Loading product types" in any output, no `products/index.html` written, `app-shell.html` keeps the Blazor loader.
- Guard test, forcing `/products` back in: fails with `'/products' was still showing a loading state ('placeholder-wave') when captured`, exit 1, nothing written.

## Trade-off

`/products` loses its static first paint and per-page prerendered meta; it now renders after the WASM runtime boots. Product SEO is still covered by the static `product/{slug}` pages from `tools/StaticProductPages`.

## Follow-ups (not in this PR)

- A post-prerender smoke step that serves the publish folder and asserts each route has no console errors and its expected heading.
- Product-type cards use a Blazor `@onclick` rather than a real link; turning them into anchors would make them work on any non-Blazor render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
