### PR TITLE
Give every content-page header the homepage hero's look

### DIFF
--- a/wwwroot/css/content-pages.css
+++ b/wwwroot/css/content-pages.css
@@ -6,23 +6,29 @@
    navy #1A2C54 / #0B1F33, teal #3D8FB5, cyan accent #2de0e5.
    ========================================================= */
 
+/* Same treatment as the homepage hero (Pages/Components/Hero.razor.css):
+   the pond poster under the teal-to-navy overlay at 82 % -- so every
+   page opens on the one look the site leads with, rather than a second,
+   navy-only palette. Kept as background layers (no extra elements): the
+   overlay's rgba stops are the hero's #3D8FB5 -> #0B1F33 at its opacity. */
 .cp-hero {
     position: relative;
     overflow: hidden;
-    background: linear-gradient(135deg, #0B1F33 0%, #1A2C54 60%, #3D8FB5 150%);
+    background-color: #0B1F33;
+    background-image:
+        linear-gradient(180deg, rgba(61, 143, 181, 0.82) 0%, rgba(11, 31, 51, 0.82) 100%),
+        url("/images/hero-poster-wide.jpg");
+    background-image:
+        linear-gradient(180deg, rgba(61, 143, 181, 0.82) 0%, rgba(11, 31, 51, 0.82) 100%),
+        image-set(
+            url("/images/hero-poster-wide.avif") type("image/avif"),
+            url("/images/hero-poster-wide.jpg") type("image/jpeg"));
+    background-position: center;
+    background-size: cover;
+    background-repeat: no-repeat;
     color: #fff;
     padding: 3.5rem 1.5rem 3.25rem;
     margin-bottom: 3rem;
-}
-
-.cp-hero::after {
-    content: "";
-    position: absolute;
-    inset: 0;
-    background:
-        radial-gradient(circle at 88% 12%, rgba(45, 224, 229, 0.20), transparent 42%),
-        radial-gradient(circle at 6% 95%, rgba(61, 143, 181, 0.28), transparent 45%);
-    pointer-events: none;
 }
 
 .cp-hero-inner {

--- a/wwwroot/css/content-pages.css
+++ b/wwwroot/css/content-pages.css
@@ -6,26 +6,14 @@
    navy #1A2C54 / #0B1F33, teal #3D8FB5, cyan accent #2de0e5.
    ========================================================= */
 
-/* Same treatment as the homepage hero (Pages/Components/Hero.razor.css):
-   the pond poster under the teal-to-navy overlay at 82 % -- so every
-   page opens on the one look the site leads with, rather than a second,
-   navy-only palette. Kept as background layers (no extra elements): the
-   overlay's rgba stops are the hero's #3D8FB5 -> #0B1F33 at its opacity. */
+/* The homepage hero's colours (Pages/Components/Hero.razor.css
+   .gradient-overlay: #3D8FB5 -> #0B1F33, top to bottom), so every page
+   opens on the one palette the site leads with rather than a second,
+   navy-only one. Colour only -- no imagery -- by request. */
 .cp-hero {
     position: relative;
     overflow: hidden;
-    background-color: #0B1F33;
-    background-image:
-        linear-gradient(180deg, rgba(61, 143, 181, 0.82) 0%, rgba(11, 31, 51, 0.82) 100%),
-        url("/images/hero-poster-wide.jpg");
-    background-image:
-        linear-gradient(180deg, rgba(61, 143, 181, 0.82) 0%, rgba(11, 31, 51, 0.82) 100%),
-        image-set(
-            url("/images/hero-poster-wide.avif") type("image/avif"),
-            url("/images/hero-poster-wide.jpg") type("image/jpeg"));
-    background-position: center;
-    background-size: cover;
-    background-repeat: no-repeat;
+    background: linear-gradient(180deg, #3D8FB5 0%, #0B1F33 100%);
     color: #fff;
     padding: 3.5rem 1.5rem 3.25rem;
     margin-bottom: 3rem;


### PR DESCRIPTION
## Summary

The homepage hero's colours are a teal-to-navy vertical gradient (`#3D8FB5 -> #0B1F33`). Every other page (Terms, Privacy, About, Contact, Technology, Aquaculture Oxygenation, RAS Oxygenation) opened on a different, navy-only diagonal gradient with cyan glows. This PR makes the shared `.cp-hero` header use the homepage gradient so the whole site opens on one palette.

## Change

`wwwroot/css/content-pages.css`: `.cp-hero` background is now exactly the homepage overlay gradient. The radial-glow `::after` is dropped since the homepage has none. Colour only, no imagery. Layout, padding and the 640 px breakpoint are unchanged.

## Verification

Rendered locally in headless Chromium at 1440 px: /terms, /about and /technology headers now match the homepage hero's colours.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
