### PR TITLE
Show a neutral pre-boot shell on app routes instead of the homepage hero

### DIFF
--- a/wwwroot/app.css
+++ b/wwwroot/app.css
@@ -403,6 +403,40 @@ code {
     animation: shellBarPulse 1.2s ease-in-out infinite;
 }
 
+/* App routes (/products, /cart, ...) are served by the same shell via
+   app-shell.html. The <head> script in index.html tags <html> with
+   .shell-app-route on any non-home path, and these rules swap the
+   homepage hero + copy for a neutral loading state until Blazor boots. */
+html.shell-app-route .shell-hero-wrap,
+html.shell-app-route .static-shell {
+    display: none;
+}
+
+.shell-route-loading {
+    display: none;
+}
+
+html.shell-app-route .shell-route-loading {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
+    min-height: 60vh;
+    color: #1A2C54;
+}
+
+.shell-route-loading-brand {
+    font-size: 1.4rem;
+    font-weight: 700;
+    letter-spacing: 0.01em;
+}
+
+.shell-route-loading-text {
+    font-size: 0.95rem;
+    color: #6B7A8F;
+}
+
 @keyframes shellBarPulse {
     0%, 100% {
         opacity: 0.35;

--- a/wwwroot/index.html
+++ b/wwwroot/index.html
@@ -49,6 +49,23 @@
          delay first paint. -->
     <link rel="stylesheet" href="app.css" />
 
+    <!-- The pre-boot shell below is a clone of the HOMEPAGE hero, but this
+         same file also serves every app route (/products, /cart, /account,
+         ...) via app-shell.html and staticwebapp.config.json's
+         navigationFallback -- so clicking "Products" showed the homepage
+         hero for the second or two Blazor takes to boot. Runs in <head>,
+         before the body is parsed, so the wrong shell never paints: on any
+         path that is not the home route the hero and the homepage copy are
+         hidden (app.css: html.shell-app-route) and a neutral loading state
+         shows instead. Locale roots (/ta, /hi, ...) are home routes too. -->
+    <script>
+        (function () {
+            var p = location.pathname.replace(/\/index\.html$/, "").replace(/\/+$/, "");
+            if (p === "" || /^\/(ta|te|kn|ml|hi|bn)$/.test(p)) return;
+            document.documentElement.classList.add("shell-app-route");
+        })();
+    </script>
+
     <!-- The other four stylesheets (~450KB combined: bootstrap.min.css,
          bootstrap-icons.min.css, content-pages.css, and the ~100KB Blazor
          scoped-CSS bundle) are not needed by the shell and were previously
@@ -104,6 +121,13 @@
              invisible, and a transition would just be another way for a
              stuck element to hide the site. -->
         <div class="shell-header-spacer" aria-hidden="true"></div>
+
+        <!-- What app routes see while Blazor boots (see the <head> script). -->
+        <div class="shell-route-loading" aria-hidden="true">
+            <span class="shell-route-loading-brand">Oxyniti</span>
+            <span class="shell-route-loading-text">Loading&hellip;</span>
+        </div>
+
         <div class="shell-hero-wrap">
             <div class="shell-hero-container">
                 <img src="/images/hero-poster-wide.avif" width="1280" height="720" fetchpriority="high" decoding="async" alt="" class="shell-hero-poster" />


### PR DESCRIPTION
## Problem

Clicking **Products** in the top bar showed the homepage hero for a second or two before the products page appeared.

`/products` (like `/cart`, `/account`, ...) is served by `app-shell.html`, which the prerender step creates as a byte copy of `index.html`. That file's pre-boot shell is a pixel clone of the homepage hero, so every app route painted the hero until Blazor booted and swapped it out.

## Fix

- `wwwroot/index.html`: a small script in `<head>` tags `<html>` with `shell-app-route` on any path that is not the home route (locale roots `/ta`, `/hi`, ... count as home). It runs before the body is parsed, so the wrong shell never paints. A `shell-route-loading` block ("Oxyniti / Loading…") is added to `#app`.
- `wwwroot/app.css`: under `html.shell-app-route`, hide `.shell-hero-wrap` and `.static-shell` and show the loading block.

The homepage itself is unaffected: `/` and `/ta` still paint the hero shell for LCP exactly as before.

## Verification (local, Blazor held back so the shell is what renders)

| Route | `<html>` class | hero | loading |
|---|---|---|---|
| `/` | (none) | shown | hidden |
| `/ta` | (none) | shown | hidden |
| `/products` | `shell-app-route` | hidden | shown |
| `/cart` | `shell-app-route` | hidden | shown |

A normal boot of `/products` completes with no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
