### PR TITLE
Give app routes a visible pre-boot shell, and guard it in CI

### DIFF
--- a/tools/Prerender/Program.cs
+++ b/tools/Prerender/Program.cs
@@ -84,6 +84,19 @@ internal static partial class Program
         using var playwright = await Playwright.CreateAsync();
         await using var browser = await playwright.Chromium.LaunchAsync(new BrowserTypeLaunchOptions { Headless = true });
 
+        // Runs BEFORE the capture loop below, and that ordering is the whole
+        // reason it can work: the loop overwrites index.html with the
+        // prerendered homepage, so this is the only moment at which BOTH
+        // pre-boot files exist on disk in their shipped form -- index.html
+        // still the WASM shell, app-shell.html the copy every app route
+        // falls back to.
+        var shellError = await VerifyPreBootShellAsync(browser, server.BaseAddress);
+        if (shellError is not null)
+        {
+            Console.Error.WriteLine($"[prerender] {shellError}");
+            return 1;
+        }
+
         using var downloader = new HttpClient();
         var failures = new List<string>();
 
@@ -114,6 +127,73 @@ internal static partial class Program
 
         Console.WriteLine($"[prerender] Wrote {routes.Count} prerendered page(s).");
         return 0;
+    }
+
+    // Guards the pre-boot shell -- what every visitor stares at until the
+    // 2.7 MB WASM payload boots.
+    //
+    // One file does two very different jobs: index.html paints the homepage
+    // hero, and its app-shell.html copy paints /login, /cart, /account and
+    // /orders through staticwebapp.config.json's navigationFallback. Hiding
+    // the hero on app routes is a CSS-only move (app.css:
+    // html.shell-app-route), so an edit that hides it WITHOUT supplying a
+    // replacement leaves those routes painting nothing at all: an 88px header
+    // band over an empty white page, indistinguishable from a dead site, for
+    // the whole boot.
+    //
+    // That shipped once already. 8d754d2 hid the hero and added a neutral
+    // placeholder; dd572ea deleted the placeholder twelve minutes later; and
+    // nothing caught that the result was a blank page, because every other
+    // gate in this pipeline measures bytes or the POST-boot DOM. This is the
+    // check that would have caught it on the day.
+    //
+    // Returns null when both shells are fine, or the failure message.
+    private static async Task<string?> VerifyPreBootShellAsync(IBrowser browser, string baseAddress)
+    {
+        // "/" is answered by index.html; "/login" has no file of its own, so
+        // the local server's SPA fallback answers it with app-shell.html --
+        // the same two files, reached the same two ways, that Static Web Apps
+        // serves in production.
+        foreach (var routePath in new[] { "/", "/login" })
+        {
+            await using var context = await browser.NewContextAsync();
+            var page = await context.NewPageAsync();
+
+            // The whole point: hold Blazor back, so what this measures is the
+            // FIRST frame rather than the booted app that replaces it.
+            await page.RouteAsync("**/_framework/**", route => route.AbortAsync());
+
+            var url = baseAddress.TrimEnd('/') + routePath;
+
+            // Load, not DOMContentLoaded: app.css carries both the shell's own
+            // styling and the html.shell-app-route rules that hide the hero,
+            // and the innerText probe below is only meaningful once they apply.
+            await page.GotoAsync(url, new PageGotoOptions
+            {
+                WaitUntil = WaitUntilState.Load,
+                Timeout = 20_000,
+            });
+
+            var text = await page.EvalOnSelectorAsync<string?>(
+                "#app",
+                "el => el.innerText.trim()");
+
+            // innerText (not textContent) is the correct probe precisely
+            // because it honours the display:none that the app-route CSS
+            // applies -- textContent would happily "pass" on a shell whose
+            // every element is hidden, which is the exact bug this guards.
+            if (string.IsNullOrWhiteSpace(text))
+            {
+                return $"Pre-boot shell for '{routePath}' paints nothing: with _framework/* blocked, #app has no "
+                     + "visible text, so a visitor sees an empty page for the entire WASM boot. Give app routes a "
+                     + "visible placeholder (wwwroot/index.html .shell-route-loading, shown by app.css under "
+                     + "html.shell-app-route) before shipping this.";
+            }
+
+            Console.WriteLine($"[prerender] pre-boot shell OK for '{routePath}' ({text!.Length} visible chars)");
+        }
+
+        return null;
     }
 
     private static string? GetArg(string[] args, string name)

--- a/wwwroot/app.css
+++ b/wwwroot/app.css
@@ -403,14 +403,112 @@ code {
     animation: shellBarPulse 1.2s ease-in-out infinite;
 }
 
-/* App routes (/products, /cart, ...) are served by the same shell via
-   app-shell.html. The <head> script in index.html tags <html> with
+/* App routes (/login, /cart, /account, ...) are served by the same shell
+   via app-shell.html. The <head> script in index.html tags <html> with
    .shell-app-route on any non-home path; hide the homepage hero + copy
-   there so only the header band and the progress line show until Blazor
-   renders the real page. */
+   there and show a neutral brand placeholder instead until Blazor renders
+   the real page.
+
+   The placeholder is not decoration. With the hero and the homepage copy
+   hidden, the only thing left in the shell is the 88px .shell-header-spacer
+   band -- so /login, /cart, /account and /orders painted a black bar over an
+   empty white page for the entire 2.7 MB WASM boot. On the rural-mobile
+   connections this app is built for that is seconds of what reads as a dead
+   site, on every hard refresh. The 2px .shell-loading-bar is too thin to
+   carry that signal on its own. */
 html.shell-app-route .shell-hero-wrap,
 html.shell-app-route .static-shell {
     display: none;
+}
+
+.shell-route-loading {
+    display: none;
+}
+
+html.shell-app-route .shell-route-loading {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 0.75rem;
+
+    /* Fills the void the hidden hero leaves behind, so the boot state is
+       centred in the viewport rather than pinned under the header band. */
+    min-height: 60vh;
+
+    color: #1A2C54;
+}
+
+.shell-route-loading-mark {
+    width: 56px;
+    height: 56px;
+    animation: shellMarkBreathe 1.6s ease-in-out infinite;
+}
+
+.shell-route-loading-brand {
+    font-size: 1.4rem;
+    font-weight: 700;
+    letter-spacing: 0.01em;
+}
+
+/* Indeterminate: nothing here knows how far the WASM download has got. It
+   only has to say "still working", which a static bar cannot. */
+.shell-route-loading-track {
+    width: 160px;
+    height: 3px;
+    border-radius: 2px;
+    background: rgba(26, 44, 84, 0.12);
+    overflow: hidden;
+}
+
+    .shell-route-loading-track span {
+        display: block;
+        width: 40%;
+        height: 100%;
+        border-radius: 2px;
+        background: #2DE0E5;
+        animation: shellTrackSlide 1.2s ease-in-out infinite;
+    }
+
+@keyframes shellMarkBreathe {
+    0%, 100% {
+        opacity: 0.55;
+    }
+
+    50% {
+        opacity: 1;
+    }
+}
+
+/* -100% .. 250% keeps the fill touching the 160px track for the whole
+   cycle: at 250% its left edge is exactly the track's right edge. Running
+   further (350%) parks it fully outside for ~a third of every cycle, which
+   reads as a dead grey line rather than progress. */
+@keyframes shellTrackSlide {
+    0% {
+        transform: translateX(-100%);
+    }
+
+    100% {
+        transform: translateX(250%);
+    }
+}
+
+/* Reduced motion: the placeholder still has to READ as "loading", so the
+   moving parts settle to their visible resting state rather than vanishing. */
+@media (prefers-reduced-motion: reduce) {
+    .shell-route-loading-mark,
+    .shell-route-loading-track span {
+        animation: none;
+    }
+
+    .shell-route-loading-mark {
+        opacity: 1;
+    }
+
+    .shell-route-loading-track span {
+        width: 100%;
+    }
 }
 
 @keyframes shellBarPulse {

--- a/wwwroot/index.html
+++ b/wwwroot/index.html
@@ -56,8 +56,9 @@
          hero for the second or two Blazor takes to boot. Runs in <head>,
          before the body is parsed, so the wrong shell never paints: on any
          path that is not the home route the hero and the homepage copy are
-         hidden (app.css: html.shell-app-route), leaving only the header band
-         and the top progress line. Locale roots (/ta, /hi, ...) are home. -->
+         hidden (app.css: html.shell-app-route) and the neutral
+         .shell-route-loading placeholder in the body shows in their place.
+         Locale roots (/ta, /hi, ...) are home routes too. -->
     <script>
         (function () {
             var p = location.pathname.replace(/\/index\.html$/, "").replace(/\/+$/, "");
@@ -121,6 +122,27 @@
              invisible, and a transition would just be another way for a
              stuck element to hide the site. -->
         <div class="shell-header-spacer" aria-hidden="true"></div>
+
+        <!-- What app routes (/login, /cart, /account, /orders) see while
+             Blazor boots. Hidden by default; app.css reveals it only under
+             html.shell-app-route, so home + the locale roots still get the
+             hero clone above.
+
+             Restores the placeholder dd572ea removed. Dropping it left the
+             app-route shell with nothing to paint but the 88px header band,
+             so a refresh on /login showed a black bar over an empty white
+             page for the whole 2.7 MB WASM boot -- indistinguishable from a
+             dead site on the rural-mobile connections this app targets. The
+             2px progress line alone was not a readable signal.
+
+             aria-hidden + data-nosnippet: this is boot chrome, not content.
+             It must never be what a crawler or a screen reader reads as the
+             page. -->
+        <div class="shell-route-loading" aria-hidden="true" data-nosnippet>
+            <img src="/oxyniti.png" width="56" height="56" alt="" decoding="async" class="shell-route-loading-mark" />
+            <div class="shell-route-loading-brand">Oxyniti</div>
+            <div class="shell-route-loading-track"><span></span></div>
+        </div>
 
         <div class="shell-hero-wrap">
             <div class="shell-hero-container">


### PR DESCRIPTION
## What you saw

A refresh on `/login` showed a black bar over an empty white page. Same on `/cart`, `/account`, `/orders`.

Not a Blazor or WASM failure — verified against production: boot completes in ~1.3 s with zero console errors and zero failed requests. It was the **pre-boot shell painting nothing**.

## Cause

One file does two jobs. `index.html` paints the homepage hero, and its `app-shell.html` copy serves every app route through `staticwebapp.config.json`'s `navigationFallback`.

- `8d754d2` correctly noticed the homepage hero was wrong on app routes and hid it — but hiding is CSS-only (`html.shell-app-route`), so it needed a replacement, and added one.
- `dd572ea` deleted that `Oxyniti / Loading…` placeholder twelve minutes later.

What was left on app routes was a single element: the 88px `.shell-header-spacer` band. Everything else was `display:none`.

## The fix

A neutral placeholder — brand mark, name, indeterminate track — centred in the void the hidden hero leaves.

- `aria-hidden` + `data-nosnippet`: this is boot chrome, never what a crawler or screen reader reads as the page.
- `prefers-reduced-motion` settles both animations to a visible resting state rather than hiding them.
- Home and the locale roots are untouched.

Measured with `_framework/*` blocked so Blazor is held back:

| route | `<html>` class | placeholder | hero | homepage copy |
|---|---|---|---|---|
| `/login` | `shell-app-route` | visible | hidden | hidden |
| `/cart` | `shell-app-route` | visible | hidden | hidden |
| `/` | *(none)* | hidden | visible | visible |
| `/ta` | *(none)* | hidden | visible | visible |

## The guard — the more important half

Nothing caught `dd572ea`, because every existing gate here measures bytes or the **post-boot** DOM. Nothing asserted the pre-boot shell paints anything.

`VerifyPreBootShellAsync` runs inside the prerender tool, which already has the local server and a browser standing, so it adds no new project and no new CI step. It runs **before** the capture loop overwrites `index.html` — the only moment both pre-boot files exist on disk in their shipped form. It blocks `_framework/*`, loads `/` and `/login`, and fails the build if `#app` has no visible text.

`innerText`, not `textContent`, is the probe — precisely because it honours the `display:none` the app-route CSS applies. `textContent` would happily pass a shell whose every element is hidden, which is the exact bug.

Verified both directions against a real published `wwwroot`:

```
# as shipped
[prerender] pre-boot shell OK for '/' (2645 visible chars)
[prerender] pre-boot shell OK for '/login' (7 visible chars)
exit=0

# with the placeholder deleted (i.e. dd572ea)
[prerender] pre-boot shell OK for '/' (2645 visible chars)
[prerender] Pre-boot shell for '/login' paints nothing: with _framework/* blocked,
            #app has no visible text, so a visitor sees an empty page for the
            entire WASM boot. ...
exit=1
```

`/` still passes in the failing case, so it fails on the real defect rather than blanket-failing.

## Not in this PR

Separately found and fixed outside the repo: the product-group image was a **2.51 MB PNG** (1536×1024, an unoptimised Adobe export), making the Products menu click take 2276 ms / 2570 KB from a Blazor-booted route in production. Replaced with a 98 KB webp — that path now measures **875–996 ms / 99 KB**. No code change was needed.

Also left alone: 7 deleted files under `wwwroot/images` present in the working tree, unrelated to this work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
