### PR TITLE
Load the product pages in parallel, and drop the pre-boot black band

### DIFF
--- a/Pages/ProductDetails.razor
+++ b/Pages/ProductDetails.razor
@@ -5,6 +5,7 @@
 @inject CartService CartService
 @inject IAuthenticationService AuthenticationService
 @inject IMakerClient MakerClient
+@inject ProductApiClient ProductApi
 @inject LocalizationService Loc
 
 <PageTitle>@(Detail?.Name ?? "Loading...")</PageTitle>
@@ -423,21 +424,18 @@ else
             await JSRuntime.InvokeVoidAsync("attachCarouselEvent", "#carouselExampleControls");
         }
 
-        try
-        {
-            await LoadSimilarProductsAsync();
-        }
-        catch (Exception ex)
-        {
-            Console.WriteLine($"[ProductDetail] Error loading similar products: {ex}");
-        }
+        // LoadSimilarProductsAsync used to be called here, unguarded by
+        // firstRender -- so the "you may also like" POST was re-issued after
+        // EVERY render: each quantity click, each add-to-cart, each language
+        // change. It now runs once, concurrently with the details call, in
+        // OnInitializedAsync.
     }
 
     private async Task LoadSimilarProductsAsync()
     {
         try
         {
-            var result = await MakerClient.ProductsBySlugAsync(new ProductRequest
+            var result = await ProductApi.ProductsBySlugAsync(new ProductRequest
             {
                 Slug = Slug,
                 Search = "",
@@ -459,9 +457,35 @@ else
     {
         Loc.OnChange += StateHasChanged;
 
+        // These three used to be awaited one after another, and from South India
+        // to UK South a single round trip to the CMS API is ~0.65 s of pure
+        // network before the server does any work at all. Chained, /product/{slug}
+        // could not paint anything for ~2.05 s (measured); issued together the
+        // same three land in ~0.93 s, because the two API calls now overlap
+        // instead of queueing.
+        //
+        // Nothing here depends on anything else here: the details call, the
+        // "you may also like" rail and the cart quantity are independent reads.
+        // Start all three, then await them in the order the page needs to paint.
+        var detailTask = LoadDetailAsync();
+        var similarTask = LoadSimilarProductsAsync();
+        var cartTask = LoadCartQuantityAsync();
+
+        // The details ARE the page: as soon as they land, paint. The rail below
+        // the fold and the quantity stepper can arrive a moment later rather than
+        // holding the whole above-the-fold render hostage to the slower of the two
+        // calls -- which is what made a two-product catalogue feel slow.
+        await detailTask;
+        StateHasChanged();
+
+        await Task.WhenAll(similarTask, cartTask);
+    }
+
+    private async Task LoadDetailAsync()
+    {
         try
         {
-            Detail = await MakerClient.ProductDetailsAsync(new ProductRequest
+            Detail = await ProductApi.ProductDetailsAsync(new ProductRequest
             {
                 Slug = Slug,
                 Search = "",
@@ -475,7 +499,10 @@ else
             Console.WriteLine($"[ProductDetail] ProductDetailsAsync failed: {ex}");
             Detail = null;
         }
+    }
 
+    private async Task LoadCartQuantityAsync()
+    {
         try
         {
             var cart = await CartService.GetCartItems();

--- a/Pages/ProductsByFilter.razor
+++ b/Pages/ProductsByFilter.razor
@@ -2,6 +2,7 @@
 @inject NavigationManager Nav
 @inject CartService CartService
 @inject IMakerClient MakerClient
+@inject ProductApiClient ProductApi
 @inject ProductCatalogService Catalog
 @inject IAuthenticationService AuthenticationService
 @inject IJSRuntime JS
@@ -187,19 +188,40 @@
     {
         Loc.OnChange += StateHasChanged;
 
-        // fetch all types so the “Filter Product Types” dropdown can be populated
-        // -- the shared, cached catalogue call (see ProductCatalogService); never throws.
-        AllTypes = (await Catalog.GetGroupsAsync()).ToList();
+        // The products grid is what this page is FOR, and it does not depend on
+        // the type list -- LoadProducts sends the slug from the route. Awaiting
+        // the catalogue first meant that on a cold boot (before Program.cs's
+        // preload had landed) the grid did not even start loading until a whole
+        // extra round trip had come back: ~0.65 s of pure network, South India to
+        // UK South, added to a page showing two products. Start both, await both.
+        //
+        // GetGroupsAsync is the shared, cached catalogue call (see
+        // ProductCatalogService) and never throws; LoadProducts handles its own
+        // failures, so the only reason for the try here is an unexpected one.
+        var typesTask = Catalog.GetGroupsAsync();
 
-        // initial load
+        Task productsTask;
         try
         {
-            await LoadProducts();
+            productsTask = LoadProducts();
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"[Products] Initial LoadProducts failed: {ex}");
+            productsTask = Task.CompletedTask;
+        }
+
+        try
+        {
+            await productsTask;
         }
         catch (Exception ex)
         {
             Console.WriteLine($"[Products] Initial LoadProducts failed: {ex}");
         }
+
+        // Only the filter dropdown waits on this, so it is awaited last.
+        AllTypes = (await typesTask).ToList();
     }
 
     private async Task LoadProducts()
@@ -218,7 +240,7 @@
 
         try
         {
-            var result = await MakerClient.ProductsBySlugAsync(body: request);
+            var result = await ProductApi.ProductsBySlugAsync(request);
             FilteredProducts = result.Products.ToList();
             TotalPages = result.TotalPages;
         }

--- a/Program.cs
+++ b/Program.cs
@@ -20,6 +20,10 @@ builder.Services.AddSingleton<AuthReadyGate>();
 builder.Services.AddSingleton<DemoService>();
 builder.Services.AddSingleton<BusinessInfoService>();
 builder.Services.AddSingleton<ProductCatalogService>();
+// Reads ProductsBySlug/ProductDetails over GET so the browser can cache them,
+// falling back to the generated client's POST. Registered after AddMakerClient
+// resolves IMakerClient at first use, not here, so ordering does not matter.
+builder.Services.AddSingleton<ProductApiClient>();
 builder.Services.AddSingleton<LocalizationService>();
 builder.Services.AddSingleton<IDemoAccountService, DemoAccountService>();
 builder.Services.AddOptions<StripeSettings>()

--- a/Services/ProductApiClient.cs
+++ b/Services/ProductApiClient.cs
@@ -1,0 +1,152 @@
+using System.Net;
+using System.Text.Json;
+using Maker.RampEdge;
+using Maker.RampEdge.Configuration;
+using Microsoft.Extensions.Options;
+
+namespace Oxyniti.Services
+{
+    /// <summary>
+    /// Reads the two product endpoints over GET instead of the generated client's
+    /// POST, so the browser can cache them.
+    ///
+    /// Why this exists at all: a browser will never cache a POST response, whatever
+    /// Cache-Control says. /api/public/ProductGroups was made a cacheable GET and a
+    /// storefront refresh now repaints its catalogue with no network round trip;
+    /// ProductsBySlug and ProductDetails could not get that win because
+    /// Maker.RampEdgeV1 ships compiled with both bound to POST. The API now serves
+    /// both verbs from the same repository method and the same server cache, so
+    /// this calls the GET and gets the browser cache for free.
+    ///
+    /// The generated client stays as the fallback. The two deploy separately -- the
+    /// storefront can go live against an API that predates the GET routes -- so a
+    /// missing route must degrade to the old path, not to an empty catalogue.
+    /// </summary>
+    public sealed class ProductApiClient
+    {
+        private readonly HttpClient _http;
+        private readonly IMakerClient _makerClient;
+        private readonly string _businessUnitKey;
+
+        /// <summary>
+        /// Set once the API is known not to serve the GET routes, so every later
+        /// call goes straight to the POST instead of paying a doomed round trip
+        /// first. Only the LIST endpoint may set this -- see TryGetListAsync.
+        /// </summary>
+        private bool _getRoutesUnavailable;
+
+        public ProductApiClient(IMakerClient makerClient, IOptions<RampEdgeSettings> settings)
+        {
+            _makerClient = makerClient;
+            _businessUnitKey = settings.Value.BusinessUnitKey ?? "";
+
+            _http = new HttpClient { BaseAddress = new Uri(settings.Value.BaseAddress) };
+            _http.DefaultRequestHeaders.Add("businessunitkey", _businessUnitKey);
+        }
+
+        public async Task<ProductListResponse> ProductsBySlugAsync(ProductRequest request)
+        {
+            var viaGet = await TryGetListAsync(request);
+            if (viaGet is not null) return viaGet;
+
+            return await _makerClient.ProductsBySlugAsync(body: request);
+        }
+
+        public async Task<ProductDetailsReply?> ProductDetailsAsync(ProductRequest request)
+        {
+            var viaGet = await TryGetDetailsAsync(request);
+            if (viaGet is not null) return viaGet;
+
+            // Either the GET routes are not deployed, or the GET returned 404. The
+            // second case is ambiguous -- an undeployed route and a product that
+            // does not exist both answer 404 -- so let the POST decide rather than
+            // guessing. It is authoritative, and a genuine 404 is rare enough that
+            // the extra round trip costs nothing in practice.
+            try
+            {
+                return await _makerClient.ProductDetailsAsync(request);
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"[ProductApiClient] ProductDetailsAsync failed: {ex.Message}");
+                return null;
+            }
+        }
+
+        private async Task<ProductListResponse?> TryGetListAsync(ProductRequest request)
+        {
+            if (_getRoutesUnavailable) return null;
+
+            try
+            {
+                var url = "api/public/ProductsBySlug"
+                    + $"?slug={Uri.EscapeDataString(request.Slug ?? "")}"
+                    + $"&search={Uri.EscapeDataString(request.Search ?? "")}"
+                    + $"&sortBy={Uri.EscapeDataString(request.SortBy ?? "")}"
+                    + $"&page={request.Page}"
+                    + $"&pageSize={request.PageSize}";
+
+                using var response = await _http.GetAsync(url);
+
+                // Both are unambiguous here: a deployed route answers 200 with an
+                // empty list for an unknown slug, so 404 can only mean the route is
+                // missing, and 405 means the path routes the POST but not the GET.
+                // Latch either and stop asking. (Production answers 405 today.)
+                if (response.StatusCode is HttpStatusCode.NotFound or HttpStatusCode.MethodNotAllowed)
+                {
+                    _getRoutesUnavailable = true;
+                    return null;
+                }
+
+                if (!response.IsSuccessStatusCode) return null;
+
+                var json = await response.Content.ReadAsStringAsync();
+                return JsonSerializer.Deserialize<ProductListResponse>(json);
+            }
+            catch (Exception ex)
+            {
+                // A transport failure says nothing about whether the route exists,
+                // so this does NOT latch: fall back for this call only.
+                Console.WriteLine($"[ProductApiClient] GET ProductsBySlug failed, using POST: {ex.Message}");
+                return null;
+            }
+        }
+
+        private async Task<ProductDetailsReply?> TryGetDetailsAsync(ProductRequest request)
+        {
+            if (_getRoutesUnavailable) return null;
+
+            try
+            {
+                var url = $"api/public/ProductDetails?slug={Uri.EscapeDataString(request.Slug ?? "")}";
+
+                using var response = await _http.GetAsync(url);
+
+                // 405 is unambiguous and worth latching: the path exists (the POST
+                // is routed there) but does not accept GET, so the GET route is
+                // definitively absent -- which is exactly what an API older than
+                // the GET routes answers. A plain 404 is NOT latched: here it
+                // cannot be told apart from a product that does not exist.
+                if (response.StatusCode is HttpStatusCode.MethodNotAllowed)
+                {
+                    _getRoutesUnavailable = true;
+                    return null;
+                }
+
+                if (!response.IsSuccessStatusCode) return null;
+
+                var json = await response.Content.ReadAsStringAsync();
+                var reply = JsonSerializer.Deserialize<ProductDetailsReply>(json);
+
+                // The endpoint 404s rather than returning a bodiless 200, but a
+                // reply with no Slug is what every caller treats as "not found".
+                return string.IsNullOrEmpty(reply?.Slug) ? null : reply;
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"[ProductApiClient] GET ProductDetails failed, using POST: {ex.Message}");
+                return null;
+            }
+        }
+    }
+}

--- a/wwwroot/app.css
+++ b/wwwroot/app.css
@@ -425,14 +425,23 @@ code {
    the real page.
 
    The placeholder is not decoration. With the hero and the homepage copy
-   hidden, the only thing left in the shell is the 88px .shell-header-spacer
-   band -- so /login, /cart, /account and /orders painted a black bar over an
-   empty white page for the entire 2.7 MB WASM boot. On the rural-mobile
-   connections this app is built for that is seconds of what reads as a dead
-   site, on every hard refresh. The 2px .shell-loading-bar is too thin to
-   carry that signal on its own. */
+   hidden, the only thing left in the shell would be the 88px
+   .shell-header-spacer band -- so /login, /cart, /account and /orders painted
+   a black bar over an empty white page for the entire 2.7 MB WASM boot. On the
+   rural-mobile connections this app is built for that is seconds of what reads
+   as a dead site, on every hard refresh. The 2px .shell-loading-bar is too thin
+   to carry that signal on its own.
+
+   .shell-header-spacer is hidden here too. It exists only to reserve the real
+   sticky header's height so the HOMEPAGE hero clone below it lands on the same
+   pixel row after Blazor's swap. On an app route there is no hero clone to keep
+   aligned -- the brand placeholder centres itself in the viewport -- so the
+   spacer reserves space for a header that is not painted yet and shows up as a
+   bare dark band across the top of an otherwise empty page. Hiding it here costs
+   the home-route alignment it was built for nothing, and removes the band. */
 html.shell-app-route .shell-hero-wrap,
-html.shell-app-route .static-shell {
+html.shell-app-route .static-shell,
+html.shell-app-route .shell-header-spacer {
     display: none;
 }
 
@@ -448,8 +457,14 @@ html.shell-app-route .shell-route-loading {
     gap: 0.75rem;
 
     /* Fills the void the hidden hero leaves behind, so the boot state is
-       centred in the viewport rather than pinned under the header band. */
-    min-height: 60vh;
+       centred in the viewport rather than pinned under the header band.
+       80vh, not 100vh: bootstrap.min.css (which zeroes the UA's default 8px
+       body margin) loads non-blocking here, so during the pre-boot shell the
+       body can still carry that margin and a full-viewport block would add a
+       scrollbar to a page that has nothing to scroll. 80vh also absorbs the
+       88px .shell-header-spacer hidden above, keeping the mark on roughly the
+       same pixel row it sat on before. */
+    min-height: 80vh;
 
     color: #1A2C54;
 }


### PR DESCRIPTION
## Why

Clicking a product group, then a product, was the slowest thing left on the storefront — for a catalogue of **one group and two products**.

The product count was never the problem. From South India to UK South a single round trip to the CMS API is **~0.65 s of pure network** before the server does any work, and the product page spent three of them end to end:

```
SEQUENTIAL (what the page did):  2050 ms
PARALLEL   (same calls):          925 ms
```

## Performance

**`ProductDetails` chained three independent calls** — details, then cart, then the "you may also like" rail. Nothing there depends on anything else there. They now run together, and the page paints as soon as the *details* land rather than waiting on a rail below the fold.

**A bug found on the way:** `OnAfterRenderAsync` called `LoadSimilarProductsAsync` with **no `firstRender` guard**, so that POST was re-issued after *every* render — each quantity click, each add-to-cart, each language change. It now runs once, at init.

**`ProductsByFilter` awaited the wrong call first** — the type-list catalogue, before it started loading the products grid, though the grid takes its slug from the route and doesn't need it. On a cold boot that added a whole round trip before the grid even started. Now parallel.

**New `ProductApiClient`** reads `ProductsBySlug`/`ProductDetails` over **GET** so the browser can cache them — a repeat view within the minute costs **no network at all**. (Browsers never cache POST, whatever `Cache-Control` says.)

## The black band

The pre-boot shell painted a bare dark band across the top of app routes — visible on any hard refresh of `/products`, `/login`, `/cart`.

`.shell-header-spacer` exists only to reserve the real sticky header's height so the **homepage** hero clone lands on the same pixel row after Blazor's swap. On an app route there's no hero clone to keep aligned, so it was reserving space for a header that hadn't painted yet. Hidden there — **the home route is untouched** — and the brand placeholder moved `60vh → 80vh` to absorb the 88px and stay optically centred.

Not `100vh`: `bootstrap.min.css` (which zeroes the UA body margin) loads non-blocking here, so a full-viewport block would add a scrollbar to a page with nothing to scroll.

## Result

| | Before | After |
|---|---|---|
| product detail page | ~2.05 s | **~0.93 s** |
| product list page | ~1.47 s | **~0.82 s** |
| repeat view within 60 s | full round trip | **no network at all** |

0.65 s is the network floor India → UK South; code can't go below it.

## Verified

- GET path end to end against a locally run API on real Supabase — GET and POST return identical products
- **Deserialization into the real compiled DTOs**: a throwaway console app built against `Maker.RampEdgeV1 1.0.3` deserialized live server JSON with every field populated. Worth checking — `ProductData` uses `readme` where `ProductDetailsReply` uses `readMe`, and a mismatch would have silently nulled the field rather than erroring
- Release build clean, 0 warnings

## Deploy order

Safe in either order, independent of revred/maker-ai-mes-server#18. Production answers **405** to both GETs today, so the fallback is what runs until the API ships. 405 is latched, so only the first call pays for the discovery. A bare 404 on the details route is deliberately **not** latched — there it can't be told apart from a product that doesn't exist, so the POST decides.

## Not addressed

Hard-refresh speed. That's the Blazor WASM boot, not the API — a separate piece of work.

Measured: live ships **62 files / 2.6 MB, brotli-encoded**, against **205 files / 22.2 MB** for a local Debug build — 8.5× the bytes. (An earlier note here said the build produced no `.br` files: that was the local `bin/Release` output. The deployed site *does* serve brotli, so compression is already in hand; the remaining cost is the payload itself.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
